### PR TITLE
Feat: Add initial support for arista.cvp v3

### DIFF
--- a/atd-inventory/group_vars/cv_servers/initial_topology.yml
+++ b/atd-inventory/group_vars/cv_servers/initial_topology.yml
@@ -1,46 +1,40 @@
 ---
 CVP_DEVICES_INIT:
-  spine1:
-    name: spine1
+  - fqdn: spine1.atd.lab
     parentContainerName: STAGING
     configlets:
       - BaseIPv4_Spine1
-    imageBundle: []
-  spine2:
-    name: spine2
+  - fqdn: spine2.atd.lab
     parentContainerName: STAGING
     configlets:
       - BaseIPv4_Spine2
-    imageBundle: []
-  leaf1:
-    name: leaf1
+  - fqdn: leaf1.atd.lab
     parentContainerName: STAGING
     configlets:
       - BaseIPv4_Leaf1
-    imageBundle: []
-  leaf2:
-    name: leaf2
+  - fqdn: leaf2.atd.lab
     parentContainerName: STAGING
     configlets:
       - BaseIPv4_Leaf2
-    imageBundle: []
-  leaf3:
-    name: leaf3
+  - fqdn: leaf3.atd.lab
     parentContainerName: STAGING
     configlets:
       - BaseIPv4_Leaf3
-    imageBundle: []
-  leaf4:
-    name: leaf4
+  - fqdn: leaf4.atd.lab
     parentContainerName: STAGING
     configlets:
       - BaseIPv4_Leaf4
-    imageBundle: []
 
 CVP_CONTAINERS_INIT:
   STAGING:
-    parent_container: Tenant
+    parentContainerName: Tenant
   Hosts:
-    parent_container: Tenant
+    parentContainerName: Tenant
   CVX:
-    parent_container: Tenant
+    parentContainerName: Tenant
+
+CVP_CONTAINERS_DELETE:
+  Leaf:
+    parentContainerName: Tenant
+  Spine:
+    parentContainerName: Tenant

--- a/playbooks/atd-prepare-lab.yml
+++ b/playbooks/atd-prepare-lab.yml
@@ -7,8 +7,7 @@
        - arista.cvp
        - arista.avd
     vars:
-      run_mode: 'override'
-      execute_tasks: false
+      execute_tasks: true
     tasks:
        - name: Run AVD Provisioner
          import_role:

--- a/roles/atd_provisioner/tasks/main.yml
+++ b/roles/atd_provisioner/tasks/main.yml
@@ -1,47 +1,28 @@
 ---
 # tasks file for atd-provisioner
 # tasks file for eos-config-deploy-cvp - state=present
-- name: 'Collecting facts from CVP {{inventory_hostname}}.'
-  tags: [always]
-  arista.cvp.cv_facts:
-  register: CVP_FACTS
-
 - name: "Building Containers topology on {{inventory_hostname}}"
   tags: [provision, apply]
-  arista.cvp.cv_container:
+  arista.cvp.cv_container_v3:
     topology: '{{CVP_CONTAINERS_INIT}}'
-    cvp_facts: '{{CVP_FACTS.ansible_facts}}'
-    mode: override
-
-- name: 'Refreshing facts from CVP {{inventory_hostname}}.'
-  tags: [always]
-  arista.cvp.cv_facts:
-  register: CVP_FACTS
 
 - name: "Configure devices on {{inventory_hostname}}"
   tags: [provision, apply]
-  arista.cvp.cv_device:
+  arista.cvp.cv_device_v3:
     devices: "{{CVP_DEVICES_INIT}}"
-    cvp_facts: '{{CVP_FACTS.ansible_facts}}'
     state: present
   register: CVP_DEVICES_RESULTS
 
 - name: "Execute pending tasks on {{inventory_hostname}}"
   tags: [apply]
   arista.cvp.cv_task:
-    tasks: "{{ CVP_DEVICES_RESULTS.data.tasks }}"
-    wait: 720
+    tasks: "{{ CVP_DEVICES_RESULTS.taskIds }}"
   when:
     - execute_tasks|bool
-
-- name: 'Collecting facts from CVP {{inventory_hostname}}.'
-  tags: [always]
-  arista.cvp.cv_facts:
-  register: CVP_FACTS
+    - CVP_DEVICES_RESULTS.taskIds | length > 0
 
 - name: "Refresh Containers topology on {{inventory_hostname}}"
   tags: [provision, apply]
-  arista.cvp.cv_container:
-    topology: '{{CVP_CONTAINERS_INIT}}'
-    cvp_facts: '{{CVP_FACTS.ansible_facts}}'
-    mode: override
+  arista.cvp.cv_container_v3:
+    topology: '{{CVP_CONTAINERS_DELETE}}'
+    state: absent


### PR DESCRIPTION
Activate arista.cvp modules in version 3:

- Update initial topology format
- Transform preparation role to use v3

Todo:

- use `cv_collection: v3` in `arista.avd.eos_config_deploy_cvp` once release v2.2 is available.