### PR TITLE
Bump: update to AVD 4.x data model

### DIFF
--- a/DEMO.md
+++ b/DEMO.md
@@ -52,8 +52,8 @@ ansible-playbook playbooks/atd-prepare-lab.yml
 
 - This playbook executes the following tasks:
   - Recreates the container topology in staging format
-  - Moves nodes to appropriate container
-  - Executes pending tasks for user on CVP
+  - Moves nodes to the appropriate container
+  - Executes pending tasks for the user on CVP
 - Provisioning topology view should be similar to below
 
   ![Provisioning topo](docs/imgs/atd-topo-provisioning.png)
@@ -99,13 +99,14 @@ By default, AVD leverages EBGP for the underlay and overlay. However, these sett
 ...
 underlay_routing_protocol: OSPF
 
+...
 # bgp peer groups passwords
 bgp_peer_groups:
-  IPv4_UNDERLAY_PEERS:
+  ipv4_underlay_peers:
 ...
 ```
 
-You can rerun the build and provision playbooks to build and provision all at once. Don't forget to create a change control to finalize the deployment on the EOS nodes.
+You can rerun the build and provision playbooks to build and provision simultaneously. Remember to create a change control to finalize the deployment on the EOS nodes.
 
 ```bash
 ansible-playbook playbooks/atd-fabric-build.yml
@@ -120,21 +121,21 @@ Edit the [ATD_TENANTS_NETWORKS.yml](atd-inventory/group_vars/ATD_TENANTS_NETWORK
 # edit atd-inventory/group_vars/ATD_TENANTS_NETWORKS.yml
 tenants:
   # Tenant A Specific Information - VRFs / VLANs
-  Tenant_A:
+  - name: Tenant_A:
   ...
 
-  Tenant_B:
+  - name: Tenant_B
     mac_vrf_vni_base: 20000
     vrfs:
-      Tenant_B_OP_Zone:
+      - name: Tenant_B_OP_Zone
         vrf_vni: 20
         svis:
-          210:
+          - id: 210
             name: Tenant_B_OP_Zone_1
             tags: ['opzone']
             profile: WITH_NO_MTU
             ip_address_virtual: 10.2.10.1/24
-          211:
+          - id: 211
             name: Tenant_B_OP_Zone_2
             tags: ['opzone']
             profile: GENERIC_FULL
@@ -148,7 +149,7 @@ tenants:
   ansible-playbook playbooks/atd-fabric-provision.yml
   ```
 
-  > Once more, in CVP, create a change control and execute all tasks.
+  > Once more, create a change control in CVP and execute all tasks.
 
 ## 7. Filter VLANs deployed on the fabric
 
@@ -185,8 +186,8 @@ To enable the filtering feature, uncomment the `only_vlans_in_use` variable with
     filter:
       only_vlans_in_use: true
   node_groups:
-    pod1:
-      bgp_as: 65101
+    - group: pod1
+      bgp_as: 6510
 ...
 ```
 
@@ -219,21 +220,19 @@ To enable the filtering feature, uncomment the `only_vlans_in_use` variable with
 Currently, we have a host-specific configuration for host1 and host2 in [ATD_SERVERS.yml](atd-inventory/group_vars/ATD_SERVERS.yml). Example below:
 
 ```yaml
-  host2:
+  - name: host2
     rack: pod2
     adapters:
-      - type: nic
-        server_ports: [Eth1, Eth2, Eth3, Eth4]
+      - endpoint_ports: [Eth1, Eth2, Eth3, Eth4]
         switch_ports: [Ethernet4, Ethernet5, Ethernet4, Ethernet5]
         switches: [leaf3, leaf3, leaf4, leaf4]
         profile: TENANT_A
         port_channel:
-          state: present
           description: PortChannel
           mode: active
 ```
 
-AVD can now use a more generic definition of host-facing ports. The `network_ports` feature is useful when a series of interfaces share the same configuration. For example, if we wanted interfaces four through five on leaf3 and leaf4 configured similarly, we could do something like this.
+AVD can now use a more generic definition of host-facing ports. The `network_ports` feature is useful when a series of interfaces share the same configuration. For example, if we wanted interfaces four through five on leaf3 and leaf4 configured similarly, we could do something like the following:
 
 ```yaml
 ---
@@ -251,7 +250,7 @@ network_ports:
     profile: TENANT_A
 ```
 
-> Please note, if using this example, the connected endpoints example for host2 will have to be commented out or removed.
+> Please note, if using this example, the connected endpoints example for host2 must be commented out or removed.
 
 - Run the build and provision playbooks once again.
 
@@ -280,7 +279,7 @@ network_ports:
 
 ## 9. Validate the fabric state
 
-Once deployed, it's possible to validate the fabric state using a set of generated tests by using the AVD `eos_validate_state` role. The reports are stored in the `atd-inventory/reports` folder.
+Once deployed, it's possible to validate the fabric state using a set of generated tests using the AVD `eos_validate_state` role. The reports are stored in the `atd-inventory/reports` folder.
 
 - Run the `atd-validate-states.yml` playbook
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This repository is configured to run [`arista.cvp`](https://github.com/aristanet
   <img src='docs/imgs/cv_ansible_logo.png' alt='Arista CloudVision and Ansible'/>
 </p>
 
-To access an ATD topology, please get in touch with your Arista representative.
+To access an ATD topology, please contact your Arista representative.
 
 ## Lab topology
 

--- a/ansible.cfg
+++ b/ansible.cfg
@@ -3,7 +3,6 @@ inventory =./atd-inventory/inventory.yml
 roles_path = roles
 collections_paths = ../ansible-cvp:../ansible-avd:~/.ansible/collections:/usr/share/ansible/collections
 jinja2_extensions =  jinja2.ext.loopcontrols,jinja2.ext.do,jinja2.ext.i18n
-deprecation_warnings = False
 
 [persistent_connection]
 connect_timeout = 120

--- a/atd-inventory/documentation/ATD_FABRIC/ATD_FABRIC-documentation.md
+++ b/atd-inventory/documentation/ATD_FABRIC/ATD_FABRIC-documentation.md
@@ -1,6 +1,6 @@
 # ATD_FABRIC
 
-# Table of Contents
+## Table of Contents
 
 - [Fabric Switches and Management IP](#fabric-switches-and-management-ip)
   - [Fabric Switches with inband Management IP](#fabric-switches-with-inband-management-ip)
@@ -13,24 +13,25 @@
   - [VTEP Loopback VXLAN Tunnel Source Interfaces (VTEPs Only)](#vtep-loopback-vxlan-tunnel-source-interfaces-vteps-only)
   - [VTEP Loopback Node allocation](#vtep-loopback-node-allocation)
 
-# Fabric Switches and Management IP
+## Fabric Switches and Management IP
 
-| POD | Type | Node | Management IP | Platform | Provisioned in CloudVision |
-| --- | ---- | ---- | ------------- | -------- | -------------------------- |
-| ATD_FABRIC | l3leaf | leaf1 | 192.168.0.12/24 | vEOS-LAB | Provisioned |
-| ATD_FABRIC | l3leaf | leaf2 | 192.168.0.13/24 | vEOS-LAB | Provisioned |
-| ATD_FABRIC | l3leaf | leaf3 | 192.168.0.14/24 | vEOS-LAB | Provisioned |
-| ATD_FABRIC | l3leaf | leaf4 | 192.168.0.15/24 | vEOS-LAB | Provisioned |
-| ATD_FABRIC | spine | spine1 | 192.168.0.10/24 | vEOS-LAB | Provisioned |
-| ATD_FABRIC | spine | spine2 | 192.168.0.11/24 | vEOS-LAB | Provisioned |
+| POD | Type | Node | Management IP | Platform | Provisioned in CloudVision | Serial Number |
+| --- | ---- | ---- | ------------- | -------- | -------------------------- | ------------- |
+| ATD_FABRIC | l3leaf | leaf1 | 192.168.0.12/24 | vEOS-lab | Provisioned | - |
+| ATD_FABRIC | l3leaf | leaf2 | 192.168.0.13/24 | vEOS-lab | Provisioned | - |
+| ATD_FABRIC | l3leaf | leaf3 | 192.168.0.14/24 | vEOS-lab | Provisioned | - |
+| ATD_FABRIC | l3leaf | leaf4 | 192.168.0.15/24 | vEOS-lab | Provisioned | - |
+| ATD_FABRIC | spine | spine1 | 192.168.0.10/24 | vEOS-lab | Provisioned | - |
+| ATD_FABRIC | spine | spine2 | 192.168.0.11/24 | vEOS-lab | Provisioned | - |
 
 > Provision status is based on Ansible inventory declaration and do not represent real status from CloudVision.
 
-## Fabric Switches with inband Management IP
+### Fabric Switches with inband Management IP
+
 | POD | Type | Node | Management IP | Inband Interface |
 | --- | ---- | ---- | ------------- | ---------------- |
 
-# Fabric Topology
+## Fabric Topology
 
 | Type | Node | Node Interface | Peer Type | Peer Node | Peer Interface |
 | ---- | ---- | -------------- | --------- | ----------| -------------- |
@@ -47,15 +48,15 @@
 | l3leaf | leaf4 | Ethernet2 | spine | spine1 | Ethernet5 |
 | l3leaf | leaf4 | Ethernet3 | spine | spine2 | Ethernet5 |
 
-# Fabric IP Allocation
+## Fabric IP Allocation
 
-## Fabric Point-To-Point Links
+### Fabric Point-To-Point Links
 
 | Uplink IPv4 Pool | Available Addresses | Assigned addresses | Assigned Address % |
 | ---------------- | ------------------- | ------------------ | ------------------ |
 | 172.30.255.0/24 | 256 | 16 | 6.25 % |
 
-## Point-To-Point Links Node Allocation
+### Point-To-Point Links Node Allocation
 
 | Node | Node Interface | Node IP Address | Peer Node | Peer Interface | Peer IP Address |
 | ---- | -------------- | --------------- | --------- | -------------- | --------------- |
@@ -68,13 +69,13 @@
 | leaf4 | Ethernet2 | 172.30.255.13/31 | spine1 | Ethernet5 | 172.30.255.12/31 |
 | leaf4 | Ethernet3 | 172.30.255.15/31 | spine2 | Ethernet5 | 172.30.255.14/31 |
 
-## Loopback Interfaces (BGP EVPN Peering)
+### Loopback Interfaces (BGP EVPN Peering)
 
 | Loopback Pool | Available Addresses | Assigned addresses | Assigned Address % |
 | ------------- | ------------------- | ------------------ | ------------------ |
 | 192.0.255.0/24 | 256 | 6 | 2.35 % |
 
-## Loopback0 Interfaces Node Allocation
+### Loopback0 Interfaces Node Allocation
 
 | POD | Node | Loopback0 |
 | --- | ---- | --------- |
@@ -85,13 +86,13 @@
 | ATD_FABRIC | spine1 | 192.0.255.1/32 |
 | ATD_FABRIC | spine2 | 192.0.255.2/32 |
 
-## VTEP Loopback VXLAN Tunnel Source Interfaces (VTEPs Only)
+### VTEP Loopback VXLAN Tunnel Source Interfaces (VTEPs Only)
 
 | VTEP Loopback Pool | Available Addresses | Assigned addresses | Assigned Address % |
 | --------------------- | ------------------- | ------------------ | ------------------ |
 | 192.0.254.0/24 | 256 | 4 | 1.57 % |
 
-## VTEP Loopback Node allocation
+### VTEP Loopback Node allocation
 
 | POD | Node | Loopback1 |
 | --- | ---- | --------- |

--- a/atd-inventory/documentation/devices/leaf1.md
+++ b/atd-inventory/documentation/devices/leaf1.md
@@ -1,13 +1,12 @@
 # leaf1
-# Table of Contents
+
+## Table of Contents
 
 - [Management](#management)
   - [Management Interfaces](#management-interfaces)
   - [DNS Domain](#dns-domain)
-  - [Name Servers](#name-servers)
+  - [IP Name Servers](#ip-name-servers)
   - [Management API HTTP](#management-api-http)
-- [Authentication](#authentication)
-- [Monitoring](#monitoring)
 - [MLAG](#mlag)
   - [MLAG Summary](#mlag-summary)
   - [MLAG Device Configuration](#mlag-device-configuration)
@@ -40,34 +39,32 @@
 - [Filters](#filters)
   - [Prefix-lists](#prefix-lists)
   - [Route-maps](#route-maps)
-- [ACL](#acl)
 - [VRF Instances](#vrf-instances)
   - [VRF Instances Summary](#vrf-instances-summary)
   - [VRF Instances Device Configuration](#vrf-instances-device-configuration)
 - [Virtual Source NAT](#virtual-source-nat)
   - [Virtual Source NAT Summary](#virtual-source-nat-summary)
   - [Virtual Source NAT Configuration](#virtual-source-nat-configuration)
-- [Quality Of Service](#quality-of-service)
 
-# Management
+## Management
 
-## Management Interfaces
+### Management Interfaces
 
-### Management Interfaces Summary
+#### Management Interfaces Summary
 
-#### IPv4
+##### IPv4
 
 | Management Interface | description | Type | VRF | IP Address | Gateway |
 | -------------------- | ----------- | ---- | --- | ---------- | ------- |
 | Management1 | oob_management | oob | default | 192.168.0.12/24 | 192.168.0.1 |
 
-#### IPv6
+##### IPv6
 
 | Management Interface | description | Type | VRF | IPv6 Address | IPv6 Gateway |
 | -------------------- | ----------- | ---- | --- | ------------ | ------------ |
-| Management1 | oob_management | oob | default | -  | - |
+| Management1 | oob_management | oob | default | - | - |
 
-### Management Interfaces Device Configuration
+#### Management Interfaces Device Configuration
 
 ```eos
 !
@@ -77,48 +74,48 @@ interface Management1
    ip address 192.168.0.12/24
 ```
 
-## DNS Domain
+### DNS Domain
 
-### DNS domain: atd.lab
+#### DNS domain: atd.lab
 
-### DNS Domain Device Configuration
+#### DNS Domain Device Configuration
 
 ```eos
 dns domain atd.lab
 !
 ```
 
-## Name Servers
+### IP Name Servers
 
-### Name Servers Summary
+#### IP Name Servers Summary
 
-| Name Server | Source VRF |
-| ----------- | ---------- |
-| 192.168.2.1 | default |
-| 8.8.8.8 | default |
+| Name Server | VRF | Priority |
+| ----------- | --- | -------- |
+| 192.168.2.1 | default | - |
+| 8.8.8.8 | default | - |
 
-### Name Servers Device Configuration
+#### IP Name Servers Device Configuration
 
 ```eos
 ip name-server vrf default 8.8.8.8
 ip name-server vrf default 192.168.2.1
 ```
 
-## Management API HTTP
+### Management API HTTP
 
-### Management API HTTP Summary
+#### Management API HTTP Summary
 
 | HTTP | HTTPS | Default Services |
 | ---- | ----- | ---------------- |
 | False | True | - |
 
-### Management API VRF Access
+#### Management API VRF Access
 
 | VRF Name | IPv4 ACL | IPv6 ACL |
 | -------- | -------- | -------- |
 | default | - | - |
 
-### Management API HTTP Configuration
+#### Management API HTTP Configuration
 
 ```eos
 !
@@ -130,13 +127,9 @@ management api http-commands
       no shutdown
 ```
 
-# Authentication
+## MLAG
 
-# Monitoring
-
-# MLAG
-
-## MLAG Summary
+### MLAG Summary
 
 | Domain-id | Local-interface | Peer-address | Peer-link |
 | --------- | --------------- | ------------ | --------- |
@@ -144,7 +137,7 @@ management api http-commands
 
 Dual primary detection is disabled.
 
-## MLAG Device Configuration
+### MLAG Device Configuration
 
 ```eos
 !
@@ -157,23 +150,23 @@ mlag configuration
    reload-delay non-mlag 330
 ```
 
-# Spanning Tree
+## Spanning Tree
 
-## Spanning Tree Summary
+### Spanning Tree Summary
 
 STP mode: **mstp**
 
-### MSTP Instance and Priority
+#### MSTP Instance and Priority
 
 | Instance(s) | Priority |
 | -------- | -------- |
 | 0 | 16384 |
 
-### Global Spanning-Tree Settings
+#### Global Spanning-Tree Settings
 
 - Spanning Tree disabled for VLANs: **4093-4094**
 
-## Spanning Tree Device Configuration
+### Spanning Tree Device Configuration
 
 ```eos
 !
@@ -182,24 +175,24 @@ no spanning-tree vlan-id 4093-4094
 spanning-tree mst 0 priority 16384
 ```
 
-# Internal VLAN Allocation Policy
+## Internal VLAN Allocation Policy
 
-## Internal VLAN Allocation Policy Summary
+### Internal VLAN Allocation Policy Summary
 
 | Policy Allocation | Range Beginning | Range Ending |
 | ------------------| --------------- | ------------ |
 | ascending | 1006 | 1199 |
 
-## Internal VLAN Allocation Policy Configuration
+### Internal VLAN Allocation Policy Configuration
 
 ```eos
 !
 vlan internal order ascending range 1006 1199
 ```
 
-# VLANs
+## VLANs
 
-## VLANs Summary
+### VLANs Summary
 
 | VLAN ID | Name | Trunk Groups |
 | ------- | ---- | ------------ |
@@ -209,7 +202,7 @@ vlan internal order ascending range 1006 1199
 | 4093 | LEAF_PEER_L3 | LEAF_PEER_L3 |
 | 4094 | MLAG_PEER | MLAG |
 
-## VLANs Device Configuration
+### VLANs Device Configuration
 
 ```eos
 !
@@ -232,31 +225,31 @@ vlan 4094
    trunk group MLAG
 ```
 
-# Interfaces
+## Interfaces
 
-## Ethernet Interfaces
+### Ethernet Interfaces
 
-### Ethernet Interfaces Summary
+#### Ethernet Interfaces Summary
 
-#### L2
+##### L2
 
 | Interface | Description | Mode | VLANs | Native VLAN | Trunk Group | Channel-Group |
 | --------- | ----------- | ---- | ----- | ----------- | ----------- | ------------- |
-| Ethernet1 | MLAG_PEER_leaf2_Ethernet1 | *trunk | *2-4094 | *- | *['LEAF_PEER_L3', 'MLAG'] | 1 |
+| Ethernet1 | MLAG_PEER_leaf2_Ethernet1 | *trunk | *- | *- | *['LEAF_PEER_L3', 'MLAG'] | 1 |
 | Ethernet4 | host1_Eth1 | *access | *110 | *- | *- | 4 |
 | Ethernet5 | host1_Eth2 | *access | *110 | *- | *- | 4 |
-| Ethernet6 | MLAG_PEER_leaf2_Ethernet6 | *trunk | *2-4094 | *- | *['LEAF_PEER_L3', 'MLAG'] | 1 |
+| Ethernet6 | MLAG_PEER_leaf2_Ethernet6 | *trunk | *- | *- | *['LEAF_PEER_L3', 'MLAG'] | 1 |
 
 *Inherited from Port-Channel Interface
 
-#### IPv4
+##### IPv4
 
 | Interface | Description | Type | Channel Group | IP Address | VRF |  MTU | Shutdown | ACL In | ACL Out |
 | --------- | ----------- | -----| ------------- | ---------- | ----| ---- | -------- | ------ | ------- |
 | Ethernet2 | P2P_LINK_TO_SPINE1_Ethernet2 | routed | - | 172.30.255.1/31 | default | 1500 | False | - | - |
 | Ethernet3 | P2P_LINK_TO_SPINE2_Ethernet2 | routed | - | 172.30.255.3/31 | default | 1500 | False | - | - |
 
-### Ethernet Interfaces Device Configuration
+#### Ethernet Interfaces Device Configuration
 
 ```eos
 !
@@ -295,18 +288,18 @@ interface Ethernet6
    channel-group 1 mode active
 ```
 
-## Port-Channel Interfaces
+### Port-Channel Interfaces
 
-### Port-Channel Interfaces Summary
+#### Port-Channel Interfaces Summary
 
-#### L2
+##### L2
 
 | Interface | Description | Type | Mode | VLANs | Native VLAN | Trunk Group | LACP Fallback Timeout | LACP Fallback Mode | MLAG ID | EVPN ESI |
 | --------- | ----------- | ---- | ---- | ----- | ----------- | ------------| --------------------- | ------------------ | ------- | -------- |
-| Port-Channel1 | MLAG_PEER_leaf2_Po1 | switched | trunk | 2-4094 | - | ['LEAF_PEER_L3', 'MLAG'] | - | - | - | - |
+| Port-Channel1 | MLAG_PEER_leaf2_Po1 | switched | trunk | - | - | ['LEAF_PEER_L3', 'MLAG'] | - | - | - | - |
 | Port-Channel4 | host1_PortChannel | switched | access | 110 | - | - | - | - | 4 | - |
 
-### Port-Channel Interfaces Device Configuration
+#### Port-Channel Interfaces Device Configuration
 
 ```eos
 !
@@ -314,7 +307,6 @@ interface Port-Channel1
    description MLAG_PEER_leaf2_Po1
    no shutdown
    switchport
-   switchport trunk allowed vlan 2-4094
    switchport mode trunk
    switchport trunk group LEAF_PEER_L3
    switchport trunk group MLAG
@@ -327,11 +319,11 @@ interface Port-Channel4
    mlag 4
 ```
 
-## Loopback Interfaces
+### Loopback Interfaces
 
-### Loopback Interfaces Summary
+#### Loopback Interfaces Summary
 
-#### IPv4
+##### IPv4
 
 | Interface | Description | VRF | IP Address |
 | --------- | ----------- | --- | ---------- |
@@ -339,7 +331,7 @@ interface Port-Channel4
 | Loopback1 | VTEP_VXLAN_Tunnel_Source | default | 192.0.254.3/32 |
 | Loopback100 | Tenant_A_OP_Zone_VTEP_DIAGNOSTICS | Tenant_A_OP_Zone | 10.255.1.3/32 |
 
-#### IPv6
+##### IPv6
 
 | Interface | Description | VRF | IPv6 Address |
 | --------- | ----------- | --- | ------------ |
@@ -348,7 +340,7 @@ interface Port-Channel4
 | Loopback100 | Tenant_A_OP_Zone_VTEP_DIAGNOSTICS | Tenant_A_OP_Zone | - |
 
 
-### Loopback Interfaces Device Configuration
+#### Loopback Interfaces Device Configuration
 
 ```eos
 !
@@ -369,9 +361,9 @@ interface Loopback100
    ip address 10.255.1.3/32
 ```
 
-## VLAN Interfaces
+### VLAN Interfaces
 
-### VLAN Interfaces Summary
+#### VLAN Interfaces Summary
 
 | Interface | Description | VRF |  MTU | Shutdown |
 | --------- | ----------- | --- | ---- | -------- |
@@ -380,7 +372,7 @@ interface Loopback100
 | Vlan4093 | MLAG_PEER_L3_PEERING | default | 1500 | False |
 | Vlan4094 | MLAG_PEER | default | 1500 | False |
 
-#### IPv4
+##### IPv4
 
 | Interface | VRF | IP Address | IP Address Virtual | IP Router Virtual Address | VRRP | ACL In | ACL Out |
 | --------- | --- | ---------- | ------------------ | ------------------------- | ---- | ------ | ------- |
@@ -389,7 +381,7 @@ interface Loopback100
 | Vlan4093 |  default  |  10.255.251.0/31  |  -  |  -  |  -  |  -  |  -  |
 | Vlan4094 |  default  |  10.255.252.0/31  |  -  |  -  |  -  |  -  |  -  |
 
-### VLAN Interfaces Device Configuration
+#### VLAN Interfaces Device Configuration
 
 ```eos
 !
@@ -420,9 +412,9 @@ interface Vlan4094
    ip address 10.255.252.0/31
 ```
 
-## VXLAN Interface
+### VXLAN Interface
 
-### VXLAN Interface Summary
+#### VXLAN Interface Summary
 
 | Setting | Value |
 | ------- | ----- |
@@ -430,20 +422,20 @@ interface Vlan4094
 | UDP port | 4789 |
 | EVPN MLAG Shared Router MAC | mlag-system-id |
 
-#### VLAN to VNI, Flood List and Multicast Group Mappings
+##### VLAN to VNI, Flood List and Multicast Group Mappings
 
 | VLAN | VNI | Flood List | Multicast Group |
 | ---- | --- | ---------- | --------------- |
 | 110 | 10110 | - | - |
 | 160 | 55160 | - | - |
 
-#### VRF to VNI and Multicast Group Mappings
+##### VRF to VNI and Multicast Group Mappings
 
 | VRF | VNI | Multicast Group |
 | ---- | --- | --------------- |
 | Tenant_A_OP_Zone | 10 | - |
 
-### VXLAN Interface Device Configuration
+#### VXLAN Interface Device Configuration
 
 ```eos
 !
@@ -457,8 +449,9 @@ interface Vxlan1
    vxlan vrf Tenant_A_OP_Zone vni 10
 ```
 
-# Routing
-## Service Routing Protocols Model
+## Routing
+
+### Service Routing Protocols Model
 
 Multi agent routing protocol model enabled
 
@@ -467,39 +460,39 @@ Multi agent routing protocol model enabled
 service routing protocols model multi-agent
 ```
 
-## Virtual Router MAC Address
+### Virtual Router MAC Address
 
-### Virtual Router MAC Address Summary
+#### Virtual Router MAC Address Summary
 
-#### Virtual Router MAC Address: 00:1c:73:00:dc:01
+##### Virtual Router MAC Address: 00:1c:73:00:dc:01
 
-### Virtual Router MAC Address Configuration
+#### Virtual Router MAC Address Configuration
 
 ```eos
 !
 ip virtual-router mac-address 00:1c:73:00:dc:01
 ```
 
-## IP Routing
+### IP Routing
 
-### IP Routing Summary
+#### IP Routing Summary
 
 | VRF | Routing Enabled |
 | --- | --------------- |
 | default | True |
-| default | false |
-| Tenant_A_OP_Zone | true |
+| Tenant_A_OP_Zone | True |
 
-### IP Routing Device Configuration
+#### IP Routing Device Configuration
 
 ```eos
 !
 ip routing
 ip routing vrf Tenant_A_OP_Zone
 ```
-## IPv6 Routing
 
-### IPv6 Routing Summary
+### IPv6 Routing
+
+#### IPv6 Routing Summary
 
 | VRF | Routing Enabled |
 | --- | --------------- |
@@ -507,24 +500,24 @@ ip routing vrf Tenant_A_OP_Zone
 | default | false |
 | Tenant_A_OP_Zone | false |
 
-## Static Routes
+### Static Routes
 
-### Static Routes Summary
+#### Static Routes Summary
 
 | VRF | Destination Prefix | Next Hop IP             | Exit interface      | Administrative Distance       | Tag               | Route Name                    | Metric         |
 | --- | ------------------ | ----------------------- | ------------------- | ----------------------------- | ----------------- | ----------------------------- | -------------- |
 | default | 0.0.0.0/0 | 192.168.0.1 | - | 1 | - | - | - |
 
-### Static Routes Device Configuration
+#### Static Routes Device Configuration
 
 ```eos
 !
 ip route 0.0.0.0/0 192.168.0.1
 ```
 
-## Router BGP
+### Router BGP
 
-### Router BGP Summary
+#### Router BGP Summary
 
 | BGP AS | Router ID |
 | ------ | --------- |
@@ -532,15 +525,15 @@ ip route 0.0.0.0/0 192.168.0.1
 
 | BGP Tuning |
 | ---------- |
-| no bgp default ipv4-unicast |
-| distance bgp 20 200 200 |
 | graceful-restart restart-time 300 |
 | graceful-restart |
+| no bgp default ipv4-unicast |
+| distance bgp 20 200 200 |
 | maximum-paths 4 ecmp 4 |
 
-### Router BGP Peer Groups
+#### Router BGP Peer Groups
 
-#### EVPN-OVERLAY-PEERS
+##### EVPN-OVERLAY-PEERS
 
 | Settings | Value |
 | -------- | ----- |
@@ -551,7 +544,7 @@ ip route 0.0.0.0/0 192.168.0.1
 | Send community | all |
 | Maximum routes | 0 (no limit) |
 
-#### IPv4-UNDERLAY-PEERS
+##### IPv4-UNDERLAY-PEERS
 
 | Settings | Value |
 | -------- | ----- |
@@ -559,7 +552,7 @@ ip route 0.0.0.0/0 192.168.0.1
 | Send community | all |
 | Maximum routes | 12000 |
 
-#### MLAG-IPv4-UNDERLAY-PEER
+##### MLAG-IPv4-UNDERLAY-PEER
 
 | Settings | Value |
 | -------- | ----- |
@@ -569,65 +562,65 @@ ip route 0.0.0.0/0 192.168.0.1
 | Send community | all |
 | Maximum routes | 12000 |
 
-### BGP Neighbors
+#### BGP Neighbors
 
-| Neighbor | Remote AS | VRF | Shutdown | Send-community | Maximum-routes | Allowas-in | BFD | RIB Pre-Policy Retain |
-| -------- | --------- | --- | -------- | -------------- | -------------- | ---------- | --- | --------------------- |
-| 10.255.251.1 | Inherited from peer group MLAG-IPv4-UNDERLAY-PEER | default | - | Inherited from peer group MLAG-IPv4-UNDERLAY-PEER | Inherited from peer group MLAG-IPv4-UNDERLAY-PEER | - | - | - |
-| 172.30.255.0 | 65001 | default | - | Inherited from peer group IPv4-UNDERLAY-PEERS | Inherited from peer group IPv4-UNDERLAY-PEERS | - | - | - |
-| 172.30.255.2 | 65001 | default | - | Inherited from peer group IPv4-UNDERLAY-PEERS | Inherited from peer group IPv4-UNDERLAY-PEERS | - | - | - |
-| 192.0.255.1 | 65001 | default | - | Inherited from peer group EVPN-OVERLAY-PEERS | Inherited from peer group EVPN-OVERLAY-PEERS | - | Inherited from peer group EVPN-OVERLAY-PEERS | - |
-| 192.0.255.2 | 65001 | default | - | Inherited from peer group EVPN-OVERLAY-PEERS | Inherited from peer group EVPN-OVERLAY-PEERS | - | Inherited from peer group EVPN-OVERLAY-PEERS | - |
-| 10.255.251.1 | Inherited from peer group MLAG-IPv4-UNDERLAY-PEER | Tenant_A_OP_Zone | - | Inherited from peer group MLAG-IPv4-UNDERLAY-PEER | Inherited from peer group MLAG-IPv4-UNDERLAY-PEER | - | - | - |
+| Neighbor | Remote AS | VRF | Shutdown | Send-community | Maximum-routes | Allowas-in | BFD | RIB Pre-Policy Retain | Route-Reflector Client | Passive |
+| -------- | --------- | --- | -------- | -------------- | -------------- | ---------- | --- | --------------------- | ---------------------- | ------- |
+| 10.255.251.1 | Inherited from peer group MLAG-IPv4-UNDERLAY-PEER | default | - | Inherited from peer group MLAG-IPv4-UNDERLAY-PEER | Inherited from peer group MLAG-IPv4-UNDERLAY-PEER | - | - | - | - | - |
+| 172.30.255.0 | 65001 | default | - | Inherited from peer group IPv4-UNDERLAY-PEERS | Inherited from peer group IPv4-UNDERLAY-PEERS | - | - | - | - | - |
+| 172.30.255.2 | 65001 | default | - | Inherited from peer group IPv4-UNDERLAY-PEERS | Inherited from peer group IPv4-UNDERLAY-PEERS | - | - | - | - | - |
+| 192.0.255.1 | 65001 | default | - | Inherited from peer group EVPN-OVERLAY-PEERS | Inherited from peer group EVPN-OVERLAY-PEERS | - | Inherited from peer group EVPN-OVERLAY-PEERS | - | - | - |
+| 192.0.255.2 | 65001 | default | - | Inherited from peer group EVPN-OVERLAY-PEERS | Inherited from peer group EVPN-OVERLAY-PEERS | - | Inherited from peer group EVPN-OVERLAY-PEERS | - | - | - |
+| 10.255.251.1 | Inherited from peer group MLAG-IPv4-UNDERLAY-PEER | Tenant_A_OP_Zone | - | Inherited from peer group MLAG-IPv4-UNDERLAY-PEER | Inherited from peer group MLAG-IPv4-UNDERLAY-PEER | - | - | - | - | - |
 
-### Router BGP EVPN Address Family
+#### Router BGP EVPN Address Family
 
-#### EVPN Peer Groups
+##### EVPN Peer Groups
 
-| Peer Group | Activate |
-| ---------- | -------- |
-| EVPN-OVERLAY-PEERS | True |
+| Peer Group | Activate | Encapsulation |
+| ---------- | -------- | ------------- |
+| EVPN-OVERLAY-PEERS | True | default |
 
-### Router BGP VLAN Aware Bundles
+#### Router BGP VLAN Aware Bundles
 
 | VLAN Aware Bundle | Route-Distinguisher | Both Route-Target | Import Route Target | Export Route-Target | Redistribute | VLANs |
 | ----------------- | ------------------- | ----------------- | ------------------- | ------------------- | ------------ | ----- |
 | Tenant_A_OP_Zone | 192.0.255.3:10 | 10:10 | - | - | learned | 110 |
 | Tenant_A_VMOTION | 192.0.255.3:55160 | 55160:55160 | - | - | learned | 160 |
 
-### Router BGP VRFs
+#### Router BGP VRFs
 
 | VRF | Route-Distinguisher | Redistribute |
 | --- | ------------------- | ------------ |
 | Tenant_A_OP_Zone | 192.0.255.3:10 | connected |
 
-### Router BGP Device Configuration
+#### Router BGP Device Configuration
 
 ```eos
 !
 router bgp 65101
    router-id 192.0.255.3
-   no bgp default ipv4-unicast
    distance bgp 20 200 200
    graceful-restart restart-time 300
    graceful-restart
    maximum-paths 4 ecmp 4
+   no bgp default ipv4-unicast
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0
    neighbor EVPN-OVERLAY-PEERS bfd
    neighbor EVPN-OVERLAY-PEERS ebgp-multihop 3
-   neighbor EVPN-OVERLAY-PEERS password 7 q+VNViP5i4rVjW1cxFv2wA==
+   neighbor EVPN-OVERLAY-PEERS password 7 <removed>
    neighbor EVPN-OVERLAY-PEERS send-community
    neighbor EVPN-OVERLAY-PEERS maximum-routes 0
    neighbor IPv4-UNDERLAY-PEERS peer group
-   neighbor IPv4-UNDERLAY-PEERS password 7 AQQvKeimxJu+uGQ/yYvv9w==
+   neighbor IPv4-UNDERLAY-PEERS password 7 <removed>
    neighbor IPv4-UNDERLAY-PEERS send-community
    neighbor IPv4-UNDERLAY-PEERS maximum-routes 12000
    neighbor MLAG-IPv4-UNDERLAY-PEER peer group
    neighbor MLAG-IPv4-UNDERLAY-PEER remote-as 65101
    neighbor MLAG-IPv4-UNDERLAY-PEER next-hop-self
    neighbor MLAG-IPv4-UNDERLAY-PEER description leaf2
-   neighbor MLAG-IPv4-UNDERLAY-PEER password 7 vnEaG8gMeQf3d3cN6PktXQ==
+   neighbor MLAG-IPv4-UNDERLAY-PEER password 7 <removed>
    neighbor MLAG-IPv4-UNDERLAY-PEER send-community
    neighbor MLAG-IPv4-UNDERLAY-PEER maximum-routes 12000
    neighbor MLAG-IPv4-UNDERLAY-PEER route-map RM-MLAG-PEER-IN in
@@ -676,17 +669,17 @@ router bgp 65101
       redistribute connected
 ```
 
-# BFD
+## BFD
 
-## Router BFD
+### Router BFD
 
-### Router BFD Multihop Summary
+#### Router BFD Multihop Summary
 
 | Interval | Minimum RX | Multiplier |
 | -------- | ---------- | ---------- |
 | 1200 | 1200 | 3 |
 
-### Router BFD Device Configuration
+#### Router BFD Device Configuration
 
 ```eos
 !
@@ -694,35 +687,35 @@ router bfd
    multihop interval 1200 min-rx 1200 multiplier 3
 ```
 
-# Multicast
+## Multicast
 
-## IP IGMP Snooping
+### IP IGMP Snooping
 
-### IP IGMP Snooping Summary
+#### IP IGMP Snooping Summary
 
 | IGMP Snooping | Fast Leave | Interface Restart Query | Proxy | Restart Query Interval | Robustness Variable |
 | ------------- | ---------- | ----------------------- | ----- | ---------------------- | ------------------- |
 | Enabled | - | - | - | - | - |
 
-### IP IGMP Snooping Device Configuration
+#### IP IGMP Snooping Device Configuration
 
 ```eos
 ```
 
-# Filters
+## Filters
 
-## Prefix-lists
+### Prefix-lists
 
-### Prefix-lists Summary
+#### Prefix-lists Summary
 
-#### PL-LOOPBACKS-EVPN-OVERLAY
+##### PL-LOOPBACKS-EVPN-OVERLAY
 
 | Sequence | Action |
 | -------- | ------ |
 | 10 | permit 192.0.255.0/24 eq 32 |
 | 20 | permit 192.0.254.0/24 eq 32 |
 
-### Prefix-lists Device Configuration
+#### Prefix-lists Device Configuration
 
 ```eos
 !
@@ -731,23 +724,23 @@ ip prefix-list PL-LOOPBACKS-EVPN-OVERLAY
    seq 20 permit 192.0.254.0/24 eq 32
 ```
 
-## Route-maps
+### Route-maps
 
-### Route-maps Summary
+#### Route-maps Summary
 
-#### RM-CONN-2-BGP
+##### RM-CONN-2-BGP
 
 | Sequence | Type | Match | Set | Sub-Route-Map | Continue |
 | -------- | ---- | ----- | --- | ------------- | -------- |
 | 10 | permit | ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY | - | - | - |
 
-#### RM-MLAG-PEER-IN
+##### RM-MLAG-PEER-IN
 
 | Sequence | Type | Match | Set | Sub-Route-Map | Continue |
 | -------- | ---- | ----- | --- | ------------- | -------- |
 | 10 | permit | - | origin incomplete | - | - |
 
-### Route-maps Device Configuration
+#### Route-maps Device Configuration
 
 ```eos
 !
@@ -759,37 +752,32 @@ route-map RM-MLAG-PEER-IN permit 10
    set origin incomplete
 ```
 
-# ACL
+## VRF Instances
 
-# VRF Instances
-
-## VRF Instances Summary
+### VRF Instances Summary
 
 | VRF Name | IP Routing |
 | -------- | ---------- |
-| default | disabled |
 | Tenant_A_OP_Zone | enabled |
 
-## VRF Instances Device Configuration
+### VRF Instances Device Configuration
 
 ```eos
 !
 vrf instance Tenant_A_OP_Zone
 ```
 
-# Virtual Source NAT
+## Virtual Source NAT
 
-## Virtual Source NAT Summary
+### Virtual Source NAT Summary
 
 | Source NAT VRF | Source NAT IP Address |
 | -------------- | --------------------- |
 | Tenant_A_OP_Zone | 10.255.1.3 |
 
-## Virtual Source NAT Configuration
+### Virtual Source NAT Configuration
 
 ```eos
 !
 ip address virtual source-nat vrf Tenant_A_OP_Zone address 10.255.1.3
 ```
-
-# Quality Of Service

--- a/atd-inventory/documentation/devices/leaf2.md
+++ b/atd-inventory/documentation/devices/leaf2.md
@@ -1,13 +1,12 @@
 # leaf2
-# Table of Contents
+
+## Table of Contents
 
 - [Management](#management)
   - [Management Interfaces](#management-interfaces)
   - [DNS Domain](#dns-domain)
-  - [Name Servers](#name-servers)
+  - [IP Name Servers](#ip-name-servers)
   - [Management API HTTP](#management-api-http)
-- [Authentication](#authentication)
-- [Monitoring](#monitoring)
 - [MLAG](#mlag)
   - [MLAG Summary](#mlag-summary)
   - [MLAG Device Configuration](#mlag-device-configuration)
@@ -40,34 +39,32 @@
 - [Filters](#filters)
   - [Prefix-lists](#prefix-lists)
   - [Route-maps](#route-maps)
-- [ACL](#acl)
 - [VRF Instances](#vrf-instances)
   - [VRF Instances Summary](#vrf-instances-summary)
   - [VRF Instances Device Configuration](#vrf-instances-device-configuration)
 - [Virtual Source NAT](#virtual-source-nat)
   - [Virtual Source NAT Summary](#virtual-source-nat-summary)
   - [Virtual Source NAT Configuration](#virtual-source-nat-configuration)
-- [Quality Of Service](#quality-of-service)
 
-# Management
+## Management
 
-## Management Interfaces
+### Management Interfaces
 
-### Management Interfaces Summary
+#### Management Interfaces Summary
 
-#### IPv4
+##### IPv4
 
 | Management Interface | description | Type | VRF | IP Address | Gateway |
 | -------------------- | ----------- | ---- | --- | ---------- | ------- |
 | Management1 | oob_management | oob | default | 192.168.0.13/24 | 192.168.0.1 |
 
-#### IPv6
+##### IPv6
 
 | Management Interface | description | Type | VRF | IPv6 Address | IPv6 Gateway |
 | -------------------- | ----------- | ---- | --- | ------------ | ------------ |
-| Management1 | oob_management | oob | default | -  | - |
+| Management1 | oob_management | oob | default | - | - |
 
-### Management Interfaces Device Configuration
+#### Management Interfaces Device Configuration
 
 ```eos
 !
@@ -77,48 +74,48 @@ interface Management1
    ip address 192.168.0.13/24
 ```
 
-## DNS Domain
+### DNS Domain
 
-### DNS domain: atd.lab
+#### DNS domain: atd.lab
 
-### DNS Domain Device Configuration
+#### DNS Domain Device Configuration
 
 ```eos
 dns domain atd.lab
 !
 ```
 
-## Name Servers
+### IP Name Servers
 
-### Name Servers Summary
+#### IP Name Servers Summary
 
-| Name Server | Source VRF |
-| ----------- | ---------- |
-| 192.168.2.1 | default |
-| 8.8.8.8 | default |
+| Name Server | VRF | Priority |
+| ----------- | --- | -------- |
+| 192.168.2.1 | default | - |
+| 8.8.8.8 | default | - |
 
-### Name Servers Device Configuration
+#### IP Name Servers Device Configuration
 
 ```eos
 ip name-server vrf default 8.8.8.8
 ip name-server vrf default 192.168.2.1
 ```
 
-## Management API HTTP
+### Management API HTTP
 
-### Management API HTTP Summary
+#### Management API HTTP Summary
 
 | HTTP | HTTPS | Default Services |
 | ---- | ----- | ---------------- |
 | False | True | - |
 
-### Management API VRF Access
+#### Management API VRF Access
 
 | VRF Name | IPv4 ACL | IPv6 ACL |
 | -------- | -------- | -------- |
 | default | - | - |
 
-### Management API HTTP Configuration
+#### Management API HTTP Configuration
 
 ```eos
 !
@@ -130,13 +127,9 @@ management api http-commands
       no shutdown
 ```
 
-# Authentication
+## MLAG
 
-# Monitoring
-
-# MLAG
-
-## MLAG Summary
+### MLAG Summary
 
 | Domain-id | Local-interface | Peer-address | Peer-link |
 | --------- | --------------- | ------------ | --------- |
@@ -144,7 +137,7 @@ management api http-commands
 
 Dual primary detection is disabled.
 
-## MLAG Device Configuration
+### MLAG Device Configuration
 
 ```eos
 !
@@ -157,23 +150,23 @@ mlag configuration
    reload-delay non-mlag 330
 ```
 
-# Spanning Tree
+## Spanning Tree
 
-## Spanning Tree Summary
+### Spanning Tree Summary
 
 STP mode: **mstp**
 
-### MSTP Instance and Priority
+#### MSTP Instance and Priority
 
 | Instance(s) | Priority |
 | -------- | -------- |
 | 0 | 16384 |
 
-### Global Spanning-Tree Settings
+#### Global Spanning-Tree Settings
 
 - Spanning Tree disabled for VLANs: **4093-4094**
 
-## Spanning Tree Device Configuration
+### Spanning Tree Device Configuration
 
 ```eos
 !
@@ -182,24 +175,24 @@ no spanning-tree vlan-id 4093-4094
 spanning-tree mst 0 priority 16384
 ```
 
-# Internal VLAN Allocation Policy
+## Internal VLAN Allocation Policy
 
-## Internal VLAN Allocation Policy Summary
+### Internal VLAN Allocation Policy Summary
 
 | Policy Allocation | Range Beginning | Range Ending |
 | ------------------| --------------- | ------------ |
 | ascending | 1006 | 1199 |
 
-## Internal VLAN Allocation Policy Configuration
+### Internal VLAN Allocation Policy Configuration
 
 ```eos
 !
 vlan internal order ascending range 1006 1199
 ```
 
-# VLANs
+## VLANs
 
-## VLANs Summary
+### VLANs Summary
 
 | VLAN ID | Name | Trunk Groups |
 | ------- | ---- | ------------ |
@@ -209,7 +202,7 @@ vlan internal order ascending range 1006 1199
 | 4093 | LEAF_PEER_L3 | LEAF_PEER_L3 |
 | 4094 | MLAG_PEER | MLAG |
 
-## VLANs Device Configuration
+### VLANs Device Configuration
 
 ```eos
 !
@@ -232,31 +225,31 @@ vlan 4094
    trunk group MLAG
 ```
 
-# Interfaces
+## Interfaces
 
-## Ethernet Interfaces
+### Ethernet Interfaces
 
-### Ethernet Interfaces Summary
+#### Ethernet Interfaces Summary
 
-#### L2
+##### L2
 
 | Interface | Description | Mode | VLANs | Native VLAN | Trunk Group | Channel-Group |
 | --------- | ----------- | ---- | ----- | ----------- | ----------- | ------------- |
-| Ethernet1 | MLAG_PEER_leaf1_Ethernet1 | *trunk | *2-4094 | *- | *['LEAF_PEER_L3', 'MLAG'] | 1 |
+| Ethernet1 | MLAG_PEER_leaf1_Ethernet1 | *trunk | *- | *- | *['LEAF_PEER_L3', 'MLAG'] | 1 |
 | Ethernet4 | host1_Eth3 | *access | *110 | *- | *- | 4 |
 | Ethernet5 | host1_Eth4 | *access | *110 | *- | *- | 4 |
-| Ethernet6 | MLAG_PEER_leaf1_Ethernet6 | *trunk | *2-4094 | *- | *['LEAF_PEER_L3', 'MLAG'] | 1 |
+| Ethernet6 | MLAG_PEER_leaf1_Ethernet6 | *trunk | *- | *- | *['LEAF_PEER_L3', 'MLAG'] | 1 |
 
 *Inherited from Port-Channel Interface
 
-#### IPv4
+##### IPv4
 
 | Interface | Description | Type | Channel Group | IP Address | VRF |  MTU | Shutdown | ACL In | ACL Out |
 | --------- | ----------- | -----| ------------- | ---------- | ----| ---- | -------- | ------ | ------- |
 | Ethernet2 | P2P_LINK_TO_SPINE1_Ethernet3 | routed | - | 172.30.255.5/31 | default | 1500 | False | - | - |
 | Ethernet3 | P2P_LINK_TO_SPINE2_Ethernet3 | routed | - | 172.30.255.7/31 | default | 1500 | False | - | - |
 
-### Ethernet Interfaces Device Configuration
+#### Ethernet Interfaces Device Configuration
 
 ```eos
 !
@@ -295,18 +288,18 @@ interface Ethernet6
    channel-group 1 mode active
 ```
 
-## Port-Channel Interfaces
+### Port-Channel Interfaces
 
-### Port-Channel Interfaces Summary
+#### Port-Channel Interfaces Summary
 
-#### L2
+##### L2
 
 | Interface | Description | Type | Mode | VLANs | Native VLAN | Trunk Group | LACP Fallback Timeout | LACP Fallback Mode | MLAG ID | EVPN ESI |
 | --------- | ----------- | ---- | ---- | ----- | ----------- | ------------| --------------------- | ------------------ | ------- | -------- |
-| Port-Channel1 | MLAG_PEER_leaf1_Po1 | switched | trunk | 2-4094 | - | ['LEAF_PEER_L3', 'MLAG'] | - | - | - | - |
+| Port-Channel1 | MLAG_PEER_leaf1_Po1 | switched | trunk | - | - | ['LEAF_PEER_L3', 'MLAG'] | - | - | - | - |
 | Port-Channel4 | host1_PortChannel | switched | access | 110 | - | - | - | - | 4 | - |
 
-### Port-Channel Interfaces Device Configuration
+#### Port-Channel Interfaces Device Configuration
 
 ```eos
 !
@@ -314,7 +307,6 @@ interface Port-Channel1
    description MLAG_PEER_leaf1_Po1
    no shutdown
    switchport
-   switchport trunk allowed vlan 2-4094
    switchport mode trunk
    switchport trunk group LEAF_PEER_L3
    switchport trunk group MLAG
@@ -327,11 +319,11 @@ interface Port-Channel4
    mlag 4
 ```
 
-## Loopback Interfaces
+### Loopback Interfaces
 
-### Loopback Interfaces Summary
+#### Loopback Interfaces Summary
 
-#### IPv4
+##### IPv4
 
 | Interface | Description | VRF | IP Address |
 | --------- | ----------- | --- | ---------- |
@@ -339,7 +331,7 @@ interface Port-Channel4
 | Loopback1 | VTEP_VXLAN_Tunnel_Source | default | 192.0.254.3/32 |
 | Loopback100 | Tenant_A_OP_Zone_VTEP_DIAGNOSTICS | Tenant_A_OP_Zone | 10.255.1.4/32 |
 
-#### IPv6
+##### IPv6
 
 | Interface | Description | VRF | IPv6 Address |
 | --------- | ----------- | --- | ------------ |
@@ -348,7 +340,7 @@ interface Port-Channel4
 | Loopback100 | Tenant_A_OP_Zone_VTEP_DIAGNOSTICS | Tenant_A_OP_Zone | - |
 
 
-### Loopback Interfaces Device Configuration
+#### Loopback Interfaces Device Configuration
 
 ```eos
 !
@@ -369,9 +361,9 @@ interface Loopback100
    ip address 10.255.1.4/32
 ```
 
-## VLAN Interfaces
+### VLAN Interfaces
 
-### VLAN Interfaces Summary
+#### VLAN Interfaces Summary
 
 | Interface | Description | VRF |  MTU | Shutdown |
 | --------- | ----------- | --- | ---- | -------- |
@@ -380,7 +372,7 @@ interface Loopback100
 | Vlan4093 | MLAG_PEER_L3_PEERING | default | 1500 | False |
 | Vlan4094 | MLAG_PEER | default | 1500 | False |
 
-#### IPv4
+##### IPv4
 
 | Interface | VRF | IP Address | IP Address Virtual | IP Router Virtual Address | VRRP | ACL In | ACL Out |
 | --------- | --- | ---------- | ------------------ | ------------------------- | ---- | ------ | ------- |
@@ -389,7 +381,7 @@ interface Loopback100
 | Vlan4093 |  default  |  10.255.251.1/31  |  -  |  -  |  -  |  -  |  -  |
 | Vlan4094 |  default  |  10.255.252.1/31  |  -  |  -  |  -  |  -  |  -  |
 
-### VLAN Interfaces Device Configuration
+#### VLAN Interfaces Device Configuration
 
 ```eos
 !
@@ -420,9 +412,9 @@ interface Vlan4094
    ip address 10.255.252.1/31
 ```
 
-## VXLAN Interface
+### VXLAN Interface
 
-### VXLAN Interface Summary
+#### VXLAN Interface Summary
 
 | Setting | Value |
 | ------- | ----- |
@@ -430,20 +422,20 @@ interface Vlan4094
 | UDP port | 4789 |
 | EVPN MLAG Shared Router MAC | mlag-system-id |
 
-#### VLAN to VNI, Flood List and Multicast Group Mappings
+##### VLAN to VNI, Flood List and Multicast Group Mappings
 
 | VLAN | VNI | Flood List | Multicast Group |
 | ---- | --- | ---------- | --------------- |
 | 110 | 10110 | - | - |
 | 160 | 55160 | - | - |
 
-#### VRF to VNI and Multicast Group Mappings
+##### VRF to VNI and Multicast Group Mappings
 
 | VRF | VNI | Multicast Group |
 | ---- | --- | --------------- |
 | Tenant_A_OP_Zone | 10 | - |
 
-### VXLAN Interface Device Configuration
+#### VXLAN Interface Device Configuration
 
 ```eos
 !
@@ -457,8 +449,9 @@ interface Vxlan1
    vxlan vrf Tenant_A_OP_Zone vni 10
 ```
 
-# Routing
-## Service Routing Protocols Model
+## Routing
+
+### Service Routing Protocols Model
 
 Multi agent routing protocol model enabled
 
@@ -467,39 +460,39 @@ Multi agent routing protocol model enabled
 service routing protocols model multi-agent
 ```
 
-## Virtual Router MAC Address
+### Virtual Router MAC Address
 
-### Virtual Router MAC Address Summary
+#### Virtual Router MAC Address Summary
 
-#### Virtual Router MAC Address: 00:1c:73:00:dc:01
+##### Virtual Router MAC Address: 00:1c:73:00:dc:01
 
-### Virtual Router MAC Address Configuration
+#### Virtual Router MAC Address Configuration
 
 ```eos
 !
 ip virtual-router mac-address 00:1c:73:00:dc:01
 ```
 
-## IP Routing
+### IP Routing
 
-### IP Routing Summary
+#### IP Routing Summary
 
 | VRF | Routing Enabled |
 | --- | --------------- |
 | default | True |
-| default | false |
-| Tenant_A_OP_Zone | true |
+| Tenant_A_OP_Zone | True |
 
-### IP Routing Device Configuration
+#### IP Routing Device Configuration
 
 ```eos
 !
 ip routing
 ip routing vrf Tenant_A_OP_Zone
 ```
-## IPv6 Routing
 
-### IPv6 Routing Summary
+### IPv6 Routing
+
+#### IPv6 Routing Summary
 
 | VRF | Routing Enabled |
 | --- | --------------- |
@@ -507,24 +500,24 @@ ip routing vrf Tenant_A_OP_Zone
 | default | false |
 | Tenant_A_OP_Zone | false |
 
-## Static Routes
+### Static Routes
 
-### Static Routes Summary
+#### Static Routes Summary
 
 | VRF | Destination Prefix | Next Hop IP             | Exit interface      | Administrative Distance       | Tag               | Route Name                    | Metric         |
 | --- | ------------------ | ----------------------- | ------------------- | ----------------------------- | ----------------- | ----------------------------- | -------------- |
 | default | 0.0.0.0/0 | 192.168.0.1 | - | 1 | - | - | - |
 
-### Static Routes Device Configuration
+#### Static Routes Device Configuration
 
 ```eos
 !
 ip route 0.0.0.0/0 192.168.0.1
 ```
 
-## Router BGP
+### Router BGP
 
-### Router BGP Summary
+#### Router BGP Summary
 
 | BGP AS | Router ID |
 | ------ | --------- |
@@ -532,15 +525,15 @@ ip route 0.0.0.0/0 192.168.0.1
 
 | BGP Tuning |
 | ---------- |
-| no bgp default ipv4-unicast |
-| distance bgp 20 200 200 |
 | graceful-restart restart-time 300 |
 | graceful-restart |
+| no bgp default ipv4-unicast |
+| distance bgp 20 200 200 |
 | maximum-paths 4 ecmp 4 |
 
-### Router BGP Peer Groups
+#### Router BGP Peer Groups
 
-#### EVPN-OVERLAY-PEERS
+##### EVPN-OVERLAY-PEERS
 
 | Settings | Value |
 | -------- | ----- |
@@ -551,7 +544,7 @@ ip route 0.0.0.0/0 192.168.0.1
 | Send community | all |
 | Maximum routes | 0 (no limit) |
 
-#### IPv4-UNDERLAY-PEERS
+##### IPv4-UNDERLAY-PEERS
 
 | Settings | Value |
 | -------- | ----- |
@@ -559,7 +552,7 @@ ip route 0.0.0.0/0 192.168.0.1
 | Send community | all |
 | Maximum routes | 12000 |
 
-#### MLAG-IPv4-UNDERLAY-PEER
+##### MLAG-IPv4-UNDERLAY-PEER
 
 | Settings | Value |
 | -------- | ----- |
@@ -569,65 +562,65 @@ ip route 0.0.0.0/0 192.168.0.1
 | Send community | all |
 | Maximum routes | 12000 |
 
-### BGP Neighbors
+#### BGP Neighbors
 
-| Neighbor | Remote AS | VRF | Shutdown | Send-community | Maximum-routes | Allowas-in | BFD | RIB Pre-Policy Retain |
-| -------- | --------- | --- | -------- | -------------- | -------------- | ---------- | --- | --------------------- |
-| 10.255.251.0 | Inherited from peer group MLAG-IPv4-UNDERLAY-PEER | default | - | Inherited from peer group MLAG-IPv4-UNDERLAY-PEER | Inherited from peer group MLAG-IPv4-UNDERLAY-PEER | - | - | - |
-| 172.30.255.4 | 65001 | default | - | Inherited from peer group IPv4-UNDERLAY-PEERS | Inherited from peer group IPv4-UNDERLAY-PEERS | - | - | - |
-| 172.30.255.6 | 65001 | default | - | Inherited from peer group IPv4-UNDERLAY-PEERS | Inherited from peer group IPv4-UNDERLAY-PEERS | - | - | - |
-| 192.0.255.1 | 65001 | default | - | Inherited from peer group EVPN-OVERLAY-PEERS | Inherited from peer group EVPN-OVERLAY-PEERS | - | Inherited from peer group EVPN-OVERLAY-PEERS | - |
-| 192.0.255.2 | 65001 | default | - | Inherited from peer group EVPN-OVERLAY-PEERS | Inherited from peer group EVPN-OVERLAY-PEERS | - | Inherited from peer group EVPN-OVERLAY-PEERS | - |
-| 10.255.251.0 | Inherited from peer group MLAG-IPv4-UNDERLAY-PEER | Tenant_A_OP_Zone | - | Inherited from peer group MLAG-IPv4-UNDERLAY-PEER | Inherited from peer group MLAG-IPv4-UNDERLAY-PEER | - | - | - |
+| Neighbor | Remote AS | VRF | Shutdown | Send-community | Maximum-routes | Allowas-in | BFD | RIB Pre-Policy Retain | Route-Reflector Client | Passive |
+| -------- | --------- | --- | -------- | -------------- | -------------- | ---------- | --- | --------------------- | ---------------------- | ------- |
+| 10.255.251.0 | Inherited from peer group MLAG-IPv4-UNDERLAY-PEER | default | - | Inherited from peer group MLAG-IPv4-UNDERLAY-PEER | Inherited from peer group MLAG-IPv4-UNDERLAY-PEER | - | - | - | - | - |
+| 172.30.255.4 | 65001 | default | - | Inherited from peer group IPv4-UNDERLAY-PEERS | Inherited from peer group IPv4-UNDERLAY-PEERS | - | - | - | - | - |
+| 172.30.255.6 | 65001 | default | - | Inherited from peer group IPv4-UNDERLAY-PEERS | Inherited from peer group IPv4-UNDERLAY-PEERS | - | - | - | - | - |
+| 192.0.255.1 | 65001 | default | - | Inherited from peer group EVPN-OVERLAY-PEERS | Inherited from peer group EVPN-OVERLAY-PEERS | - | Inherited from peer group EVPN-OVERLAY-PEERS | - | - | - |
+| 192.0.255.2 | 65001 | default | - | Inherited from peer group EVPN-OVERLAY-PEERS | Inherited from peer group EVPN-OVERLAY-PEERS | - | Inherited from peer group EVPN-OVERLAY-PEERS | - | - | - |
+| 10.255.251.0 | Inherited from peer group MLAG-IPv4-UNDERLAY-PEER | Tenant_A_OP_Zone | - | Inherited from peer group MLAG-IPv4-UNDERLAY-PEER | Inherited from peer group MLAG-IPv4-UNDERLAY-PEER | - | - | - | - | - |
 
-### Router BGP EVPN Address Family
+#### Router BGP EVPN Address Family
 
-#### EVPN Peer Groups
+##### EVPN Peer Groups
 
-| Peer Group | Activate |
-| ---------- | -------- |
-| EVPN-OVERLAY-PEERS | True |
+| Peer Group | Activate | Encapsulation |
+| ---------- | -------- | ------------- |
+| EVPN-OVERLAY-PEERS | True | default |
 
-### Router BGP VLAN Aware Bundles
+#### Router BGP VLAN Aware Bundles
 
 | VLAN Aware Bundle | Route-Distinguisher | Both Route-Target | Import Route Target | Export Route-Target | Redistribute | VLANs |
 | ----------------- | ------------------- | ----------------- | ------------------- | ------------------- | ------------ | ----- |
 | Tenant_A_OP_Zone | 192.0.255.4:10 | 10:10 | - | - | learned | 110 |
 | Tenant_A_VMOTION | 192.0.255.4:55160 | 55160:55160 | - | - | learned | 160 |
 
-### Router BGP VRFs
+#### Router BGP VRFs
 
 | VRF | Route-Distinguisher | Redistribute |
 | --- | ------------------- | ------------ |
 | Tenant_A_OP_Zone | 192.0.255.4:10 | connected |
 
-### Router BGP Device Configuration
+#### Router BGP Device Configuration
 
 ```eos
 !
 router bgp 65101
    router-id 192.0.255.4
-   no bgp default ipv4-unicast
    distance bgp 20 200 200
    graceful-restart restart-time 300
    graceful-restart
    maximum-paths 4 ecmp 4
+   no bgp default ipv4-unicast
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0
    neighbor EVPN-OVERLAY-PEERS bfd
    neighbor EVPN-OVERLAY-PEERS ebgp-multihop 3
-   neighbor EVPN-OVERLAY-PEERS password 7 q+VNViP5i4rVjW1cxFv2wA==
+   neighbor EVPN-OVERLAY-PEERS password 7 <removed>
    neighbor EVPN-OVERLAY-PEERS send-community
    neighbor EVPN-OVERLAY-PEERS maximum-routes 0
    neighbor IPv4-UNDERLAY-PEERS peer group
-   neighbor IPv4-UNDERLAY-PEERS password 7 AQQvKeimxJu+uGQ/yYvv9w==
+   neighbor IPv4-UNDERLAY-PEERS password 7 <removed>
    neighbor IPv4-UNDERLAY-PEERS send-community
    neighbor IPv4-UNDERLAY-PEERS maximum-routes 12000
    neighbor MLAG-IPv4-UNDERLAY-PEER peer group
    neighbor MLAG-IPv4-UNDERLAY-PEER remote-as 65101
    neighbor MLAG-IPv4-UNDERLAY-PEER next-hop-self
    neighbor MLAG-IPv4-UNDERLAY-PEER description leaf1
-   neighbor MLAG-IPv4-UNDERLAY-PEER password 7 vnEaG8gMeQf3d3cN6PktXQ==
+   neighbor MLAG-IPv4-UNDERLAY-PEER password 7 <removed>
    neighbor MLAG-IPv4-UNDERLAY-PEER send-community
    neighbor MLAG-IPv4-UNDERLAY-PEER maximum-routes 12000
    neighbor MLAG-IPv4-UNDERLAY-PEER route-map RM-MLAG-PEER-IN in
@@ -676,17 +669,17 @@ router bgp 65101
       redistribute connected
 ```
 
-# BFD
+## BFD
 
-## Router BFD
+### Router BFD
 
-### Router BFD Multihop Summary
+#### Router BFD Multihop Summary
 
 | Interval | Minimum RX | Multiplier |
 | -------- | ---------- | ---------- |
 | 1200 | 1200 | 3 |
 
-### Router BFD Device Configuration
+#### Router BFD Device Configuration
 
 ```eos
 !
@@ -694,35 +687,35 @@ router bfd
    multihop interval 1200 min-rx 1200 multiplier 3
 ```
 
-# Multicast
+## Multicast
 
-## IP IGMP Snooping
+### IP IGMP Snooping
 
-### IP IGMP Snooping Summary
+#### IP IGMP Snooping Summary
 
 | IGMP Snooping | Fast Leave | Interface Restart Query | Proxy | Restart Query Interval | Robustness Variable |
 | ------------- | ---------- | ----------------------- | ----- | ---------------------- | ------------------- |
 | Enabled | - | - | - | - | - |
 
-### IP IGMP Snooping Device Configuration
+#### IP IGMP Snooping Device Configuration
 
 ```eos
 ```
 
-# Filters
+## Filters
 
-## Prefix-lists
+### Prefix-lists
 
-### Prefix-lists Summary
+#### Prefix-lists Summary
 
-#### PL-LOOPBACKS-EVPN-OVERLAY
+##### PL-LOOPBACKS-EVPN-OVERLAY
 
 | Sequence | Action |
 | -------- | ------ |
 | 10 | permit 192.0.255.0/24 eq 32 |
 | 20 | permit 192.0.254.0/24 eq 32 |
 
-### Prefix-lists Device Configuration
+#### Prefix-lists Device Configuration
 
 ```eos
 !
@@ -731,23 +724,23 @@ ip prefix-list PL-LOOPBACKS-EVPN-OVERLAY
    seq 20 permit 192.0.254.0/24 eq 32
 ```
 
-## Route-maps
+### Route-maps
 
-### Route-maps Summary
+#### Route-maps Summary
 
-#### RM-CONN-2-BGP
+##### RM-CONN-2-BGP
 
 | Sequence | Type | Match | Set | Sub-Route-Map | Continue |
 | -------- | ---- | ----- | --- | ------------- | -------- |
 | 10 | permit | ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY | - | - | - |
 
-#### RM-MLAG-PEER-IN
+##### RM-MLAG-PEER-IN
 
 | Sequence | Type | Match | Set | Sub-Route-Map | Continue |
 | -------- | ---- | ----- | --- | ------------- | -------- |
 | 10 | permit | - | origin incomplete | - | - |
 
-### Route-maps Device Configuration
+#### Route-maps Device Configuration
 
 ```eos
 !
@@ -759,37 +752,32 @@ route-map RM-MLAG-PEER-IN permit 10
    set origin incomplete
 ```
 
-# ACL
+## VRF Instances
 
-# VRF Instances
-
-## VRF Instances Summary
+### VRF Instances Summary
 
 | VRF Name | IP Routing |
 | -------- | ---------- |
-| default | disabled |
 | Tenant_A_OP_Zone | enabled |
 
-## VRF Instances Device Configuration
+### VRF Instances Device Configuration
 
 ```eos
 !
 vrf instance Tenant_A_OP_Zone
 ```
 
-# Virtual Source NAT
+## Virtual Source NAT
 
-## Virtual Source NAT Summary
+### Virtual Source NAT Summary
 
 | Source NAT VRF | Source NAT IP Address |
 | -------------- | --------------------- |
 | Tenant_A_OP_Zone | 10.255.1.4 |
 
-## Virtual Source NAT Configuration
+### Virtual Source NAT Configuration
 
 ```eos
 !
 ip address virtual source-nat vrf Tenant_A_OP_Zone address 10.255.1.4
 ```
-
-# Quality Of Service

--- a/atd-inventory/documentation/devices/leaf3.md
+++ b/atd-inventory/documentation/devices/leaf3.md
@@ -1,13 +1,12 @@
 # leaf3
-# Table of Contents
+
+## Table of Contents
 
 - [Management](#management)
   - [Management Interfaces](#management-interfaces)
   - [DNS Domain](#dns-domain)
-  - [Name Servers](#name-servers)
+  - [IP Name Servers](#ip-name-servers)
   - [Management API HTTP](#management-api-http)
-- [Authentication](#authentication)
-- [Monitoring](#monitoring)
 - [MLAG](#mlag)
   - [MLAG Summary](#mlag-summary)
   - [MLAG Device Configuration](#mlag-device-configuration)
@@ -40,34 +39,32 @@
 - [Filters](#filters)
   - [Prefix-lists](#prefix-lists)
   - [Route-maps](#route-maps)
-- [ACL](#acl)
 - [VRF Instances](#vrf-instances)
   - [VRF Instances Summary](#vrf-instances-summary)
   - [VRF Instances Device Configuration](#vrf-instances-device-configuration)
 - [Virtual Source NAT](#virtual-source-nat)
   - [Virtual Source NAT Summary](#virtual-source-nat-summary)
   - [Virtual Source NAT Configuration](#virtual-source-nat-configuration)
-- [Quality Of Service](#quality-of-service)
 
-# Management
+## Management
 
-## Management Interfaces
+### Management Interfaces
 
-### Management Interfaces Summary
+#### Management Interfaces Summary
 
-#### IPv4
+##### IPv4
 
 | Management Interface | description | Type | VRF | IP Address | Gateway |
 | -------------------- | ----------- | ---- | --- | ---------- | ------- |
 | Management1 | oob_management | oob | default | 192.168.0.14/24 | 192.168.0.1 |
 
-#### IPv6
+##### IPv6
 
 | Management Interface | description | Type | VRF | IPv6 Address | IPv6 Gateway |
 | -------------------- | ----------- | ---- | --- | ------------ | ------------ |
-| Management1 | oob_management | oob | default | -  | - |
+| Management1 | oob_management | oob | default | - | - |
 
-### Management Interfaces Device Configuration
+#### Management Interfaces Device Configuration
 
 ```eos
 !
@@ -77,48 +74,48 @@ interface Management1
    ip address 192.168.0.14/24
 ```
 
-## DNS Domain
+### DNS Domain
 
-### DNS domain: atd.lab
+#### DNS domain: atd.lab
 
-### DNS Domain Device Configuration
+#### DNS Domain Device Configuration
 
 ```eos
 dns domain atd.lab
 !
 ```
 
-## Name Servers
+### IP Name Servers
 
-### Name Servers Summary
+#### IP Name Servers Summary
 
-| Name Server | Source VRF |
-| ----------- | ---------- |
-| 192.168.2.1 | default |
-| 8.8.8.8 | default |
+| Name Server | VRF | Priority |
+| ----------- | --- | -------- |
+| 192.168.2.1 | default | - |
+| 8.8.8.8 | default | - |
 
-### Name Servers Device Configuration
+#### IP Name Servers Device Configuration
 
 ```eos
 ip name-server vrf default 8.8.8.8
 ip name-server vrf default 192.168.2.1
 ```
 
-## Management API HTTP
+### Management API HTTP
 
-### Management API HTTP Summary
+#### Management API HTTP Summary
 
 | HTTP | HTTPS | Default Services |
 | ---- | ----- | ---------------- |
 | False | True | - |
 
-### Management API VRF Access
+#### Management API VRF Access
 
 | VRF Name | IPv4 ACL | IPv6 ACL |
 | -------- | -------- | -------- |
 | default | - | - |
 
-### Management API HTTP Configuration
+#### Management API HTTP Configuration
 
 ```eos
 !
@@ -130,13 +127,9 @@ management api http-commands
       no shutdown
 ```
 
-# Authentication
+## MLAG
 
-# Monitoring
-
-# MLAG
-
-## MLAG Summary
+### MLAG Summary
 
 | Domain-id | Local-interface | Peer-address | Peer-link |
 | --------- | --------------- | ------------ | --------- |
@@ -144,7 +137,7 @@ management api http-commands
 
 Dual primary detection is disabled.
 
-## MLAG Device Configuration
+### MLAG Device Configuration
 
 ```eos
 !
@@ -157,23 +150,23 @@ mlag configuration
    reload-delay non-mlag 330
 ```
 
-# Spanning Tree
+## Spanning Tree
 
-## Spanning Tree Summary
+### Spanning Tree Summary
 
 STP mode: **mstp**
 
-### MSTP Instance and Priority
+#### MSTP Instance and Priority
 
 | Instance(s) | Priority |
 | -------- | -------- |
 | 0 | 16384 |
 
-### Global Spanning-Tree Settings
+#### Global Spanning-Tree Settings
 
 - Spanning Tree disabled for VLANs: **4093-4094**
 
-## Spanning Tree Device Configuration
+### Spanning Tree Device Configuration
 
 ```eos
 !
@@ -182,24 +175,24 @@ no spanning-tree vlan-id 4093-4094
 spanning-tree mst 0 priority 16384
 ```
 
-# Internal VLAN Allocation Policy
+## Internal VLAN Allocation Policy
 
-## Internal VLAN Allocation Policy Summary
+### Internal VLAN Allocation Policy Summary
 
 | Policy Allocation | Range Beginning | Range Ending |
 | ------------------| --------------- | ------------ |
 | ascending | 1006 | 1199 |
 
-## Internal VLAN Allocation Policy Configuration
+### Internal VLAN Allocation Policy Configuration
 
 ```eos
 !
 vlan internal order ascending range 1006 1199
 ```
 
-# VLANs
+## VLANs
 
-## VLANs Summary
+### VLANs Summary
 
 | VLAN ID | Name | Trunk Groups |
 | ------- | ---- | ------------ |
@@ -209,7 +202,7 @@ vlan internal order ascending range 1006 1199
 | 4093 | LEAF_PEER_L3 | LEAF_PEER_L3 |
 | 4094 | MLAG_PEER | MLAG |
 
-## VLANs Device Configuration
+### VLANs Device Configuration
 
 ```eos
 !
@@ -232,31 +225,31 @@ vlan 4094
    trunk group MLAG
 ```
 
-# Interfaces
+## Interfaces
 
-## Ethernet Interfaces
+### Ethernet Interfaces
 
-### Ethernet Interfaces Summary
+#### Ethernet Interfaces Summary
 
-#### L2
+##### L2
 
 | Interface | Description | Mode | VLANs | Native VLAN | Trunk Group | Channel-Group |
 | --------- | ----------- | ---- | ----- | ----------- | ----------- | ------------- |
-| Ethernet1 | MLAG_PEER_leaf4_Ethernet1 | *trunk | *2-4094 | *- | *['LEAF_PEER_L3', 'MLAG'] | 1 |
+| Ethernet1 | MLAG_PEER_leaf4_Ethernet1 | *trunk | *- | *- | *['LEAF_PEER_L3', 'MLAG'] | 1 |
 | Ethernet4 | host2_Eth1 | *access | *110 | *- | *- | 4 |
 | Ethernet5 | host2_Eth2 | *access | *110 | *- | *- | 4 |
-| Ethernet6 | MLAG_PEER_leaf4_Ethernet6 | *trunk | *2-4094 | *- | *['LEAF_PEER_L3', 'MLAG'] | 1 |
+| Ethernet6 | MLAG_PEER_leaf4_Ethernet6 | *trunk | *- | *- | *['LEAF_PEER_L3', 'MLAG'] | 1 |
 
 *Inherited from Port-Channel Interface
 
-#### IPv4
+##### IPv4
 
 | Interface | Description | Type | Channel Group | IP Address | VRF |  MTU | Shutdown | ACL In | ACL Out |
 | --------- | ----------- | -----| ------------- | ---------- | ----| ---- | -------- | ------ | ------- |
 | Ethernet2 | P2P_LINK_TO_SPINE1_Ethernet4 | routed | - | 172.30.255.9/31 | default | 1500 | False | - | - |
 | Ethernet3 | P2P_LINK_TO_SPINE2_Ethernet4 | routed | - | 172.30.255.11/31 | default | 1500 | False | - | - |
 
-### Ethernet Interfaces Device Configuration
+#### Ethernet Interfaces Device Configuration
 
 ```eos
 !
@@ -295,18 +288,18 @@ interface Ethernet6
    channel-group 1 mode active
 ```
 
-## Port-Channel Interfaces
+### Port-Channel Interfaces
 
-### Port-Channel Interfaces Summary
+#### Port-Channel Interfaces Summary
 
-#### L2
+##### L2
 
 | Interface | Description | Type | Mode | VLANs | Native VLAN | Trunk Group | LACP Fallback Timeout | LACP Fallback Mode | MLAG ID | EVPN ESI |
 | --------- | ----------- | ---- | ---- | ----- | ----------- | ------------| --------------------- | ------------------ | ------- | -------- |
-| Port-Channel1 | MLAG_PEER_leaf4_Po1 | switched | trunk | 2-4094 | - | ['LEAF_PEER_L3', 'MLAG'] | - | - | - | - |
+| Port-Channel1 | MLAG_PEER_leaf4_Po1 | switched | trunk | - | - | ['LEAF_PEER_L3', 'MLAG'] | - | - | - | - |
 | Port-Channel4 | host2_PortChannel | switched | access | 110 | - | - | - | - | 4 | - |
 
-### Port-Channel Interfaces Device Configuration
+#### Port-Channel Interfaces Device Configuration
 
 ```eos
 !
@@ -314,7 +307,6 @@ interface Port-Channel1
    description MLAG_PEER_leaf4_Po1
    no shutdown
    switchport
-   switchport trunk allowed vlan 2-4094
    switchport mode trunk
    switchport trunk group LEAF_PEER_L3
    switchport trunk group MLAG
@@ -327,11 +319,11 @@ interface Port-Channel4
    mlag 4
 ```
 
-## Loopback Interfaces
+### Loopback Interfaces
 
-### Loopback Interfaces Summary
+#### Loopback Interfaces Summary
 
-#### IPv4
+##### IPv4
 
 | Interface | Description | VRF | IP Address |
 | --------- | ----------- | --- | ---------- |
@@ -339,7 +331,7 @@ interface Port-Channel4
 | Loopback1 | VTEP_VXLAN_Tunnel_Source | default | 192.0.254.5/32 |
 | Loopback100 | Tenant_A_OP_Zone_VTEP_DIAGNOSTICS | Tenant_A_OP_Zone | 10.255.1.5/32 |
 
-#### IPv6
+##### IPv6
 
 | Interface | Description | VRF | IPv6 Address |
 | --------- | ----------- | --- | ------------ |
@@ -348,7 +340,7 @@ interface Port-Channel4
 | Loopback100 | Tenant_A_OP_Zone_VTEP_DIAGNOSTICS | Tenant_A_OP_Zone | - |
 
 
-### Loopback Interfaces Device Configuration
+#### Loopback Interfaces Device Configuration
 
 ```eos
 !
@@ -369,9 +361,9 @@ interface Loopback100
    ip address 10.255.1.5/32
 ```
 
-## VLAN Interfaces
+### VLAN Interfaces
 
-### VLAN Interfaces Summary
+#### VLAN Interfaces Summary
 
 | Interface | Description | VRF |  MTU | Shutdown |
 | --------- | ----------- | --- | ---- | -------- |
@@ -380,7 +372,7 @@ interface Loopback100
 | Vlan4093 | MLAG_PEER_L3_PEERING | default | 1500 | False |
 | Vlan4094 | MLAG_PEER | default | 1500 | False |
 
-#### IPv4
+##### IPv4
 
 | Interface | VRF | IP Address | IP Address Virtual | IP Router Virtual Address | VRRP | ACL In | ACL Out |
 | --------- | --- | ---------- | ------------------ | ------------------------- | ---- | ------ | ------- |
@@ -389,7 +381,7 @@ interface Loopback100
 | Vlan4093 |  default  |  10.255.251.4/31  |  -  |  -  |  -  |  -  |  -  |
 | Vlan4094 |  default  |  10.255.252.4/31  |  -  |  -  |  -  |  -  |  -  |
 
-### VLAN Interfaces Device Configuration
+#### VLAN Interfaces Device Configuration
 
 ```eos
 !
@@ -420,9 +412,9 @@ interface Vlan4094
    ip address 10.255.252.4/31
 ```
 
-## VXLAN Interface
+### VXLAN Interface
 
-### VXLAN Interface Summary
+#### VXLAN Interface Summary
 
 | Setting | Value |
 | ------- | ----- |
@@ -430,20 +422,20 @@ interface Vlan4094
 | UDP port | 4789 |
 | EVPN MLAG Shared Router MAC | mlag-system-id |
 
-#### VLAN to VNI, Flood List and Multicast Group Mappings
+##### VLAN to VNI, Flood List and Multicast Group Mappings
 
 | VLAN | VNI | Flood List | Multicast Group |
 | ---- | --- | ---------- | --------------- |
 | 110 | 10110 | - | - |
 | 160 | 55160 | - | - |
 
-#### VRF to VNI and Multicast Group Mappings
+##### VRF to VNI and Multicast Group Mappings
 
 | VRF | VNI | Multicast Group |
 | ---- | --- | --------------- |
 | Tenant_A_OP_Zone | 10 | - |
 
-### VXLAN Interface Device Configuration
+#### VXLAN Interface Device Configuration
 
 ```eos
 !
@@ -457,8 +449,9 @@ interface Vxlan1
    vxlan vrf Tenant_A_OP_Zone vni 10
 ```
 
-# Routing
-## Service Routing Protocols Model
+## Routing
+
+### Service Routing Protocols Model
 
 Multi agent routing protocol model enabled
 
@@ -467,39 +460,39 @@ Multi agent routing protocol model enabled
 service routing protocols model multi-agent
 ```
 
-## Virtual Router MAC Address
+### Virtual Router MAC Address
 
-### Virtual Router MAC Address Summary
+#### Virtual Router MAC Address Summary
 
-#### Virtual Router MAC Address: 00:1c:73:00:dc:01
+##### Virtual Router MAC Address: 00:1c:73:00:dc:01
 
-### Virtual Router MAC Address Configuration
+#### Virtual Router MAC Address Configuration
 
 ```eos
 !
 ip virtual-router mac-address 00:1c:73:00:dc:01
 ```
 
-## IP Routing
+### IP Routing
 
-### IP Routing Summary
+#### IP Routing Summary
 
 | VRF | Routing Enabled |
 | --- | --------------- |
 | default | True |
-| default | false |
-| Tenant_A_OP_Zone | true |
+| Tenant_A_OP_Zone | True |
 
-### IP Routing Device Configuration
+#### IP Routing Device Configuration
 
 ```eos
 !
 ip routing
 ip routing vrf Tenant_A_OP_Zone
 ```
-## IPv6 Routing
 
-### IPv6 Routing Summary
+### IPv6 Routing
+
+#### IPv6 Routing Summary
 
 | VRF | Routing Enabled |
 | --- | --------------- |
@@ -507,24 +500,24 @@ ip routing vrf Tenant_A_OP_Zone
 | default | false |
 | Tenant_A_OP_Zone | false |
 
-## Static Routes
+### Static Routes
 
-### Static Routes Summary
+#### Static Routes Summary
 
 | VRF | Destination Prefix | Next Hop IP             | Exit interface      | Administrative Distance       | Tag               | Route Name                    | Metric         |
 | --- | ------------------ | ----------------------- | ------------------- | ----------------------------- | ----------------- | ----------------------------- | -------------- |
 | default | 0.0.0.0/0 | 192.168.0.1 | - | 1 | - | - | - |
 
-### Static Routes Device Configuration
+#### Static Routes Device Configuration
 
 ```eos
 !
 ip route 0.0.0.0/0 192.168.0.1
 ```
 
-## Router BGP
+### Router BGP
 
-### Router BGP Summary
+#### Router BGP Summary
 
 | BGP AS | Router ID |
 | ------ | --------- |
@@ -532,15 +525,15 @@ ip route 0.0.0.0/0 192.168.0.1
 
 | BGP Tuning |
 | ---------- |
-| no bgp default ipv4-unicast |
-| distance bgp 20 200 200 |
 | graceful-restart restart-time 300 |
 | graceful-restart |
+| no bgp default ipv4-unicast |
+| distance bgp 20 200 200 |
 | maximum-paths 4 ecmp 4 |
 
-### Router BGP Peer Groups
+#### Router BGP Peer Groups
 
-#### EVPN-OVERLAY-PEERS
+##### EVPN-OVERLAY-PEERS
 
 | Settings | Value |
 | -------- | ----- |
@@ -551,7 +544,7 @@ ip route 0.0.0.0/0 192.168.0.1
 | Send community | all |
 | Maximum routes | 0 (no limit) |
 
-#### IPv4-UNDERLAY-PEERS
+##### IPv4-UNDERLAY-PEERS
 
 | Settings | Value |
 | -------- | ----- |
@@ -559,7 +552,7 @@ ip route 0.0.0.0/0 192.168.0.1
 | Send community | all |
 | Maximum routes | 12000 |
 
-#### MLAG-IPv4-UNDERLAY-PEER
+##### MLAG-IPv4-UNDERLAY-PEER
 
 | Settings | Value |
 | -------- | ----- |
@@ -569,65 +562,65 @@ ip route 0.0.0.0/0 192.168.0.1
 | Send community | all |
 | Maximum routes | 12000 |
 
-### BGP Neighbors
+#### BGP Neighbors
 
-| Neighbor | Remote AS | VRF | Shutdown | Send-community | Maximum-routes | Allowas-in | BFD | RIB Pre-Policy Retain |
-| -------- | --------- | --- | -------- | -------------- | -------------- | ---------- | --- | --------------------- |
-| 10.255.251.5 | Inherited from peer group MLAG-IPv4-UNDERLAY-PEER | default | - | Inherited from peer group MLAG-IPv4-UNDERLAY-PEER | Inherited from peer group MLAG-IPv4-UNDERLAY-PEER | - | - | - |
-| 172.30.255.8 | 65001 | default | - | Inherited from peer group IPv4-UNDERLAY-PEERS | Inherited from peer group IPv4-UNDERLAY-PEERS | - | - | - |
-| 172.30.255.10 | 65001 | default | - | Inherited from peer group IPv4-UNDERLAY-PEERS | Inherited from peer group IPv4-UNDERLAY-PEERS | - | - | - |
-| 192.0.255.1 | 65001 | default | - | Inherited from peer group EVPN-OVERLAY-PEERS | Inherited from peer group EVPN-OVERLAY-PEERS | - | Inherited from peer group EVPN-OVERLAY-PEERS | - |
-| 192.0.255.2 | 65001 | default | - | Inherited from peer group EVPN-OVERLAY-PEERS | Inherited from peer group EVPN-OVERLAY-PEERS | - | Inherited from peer group EVPN-OVERLAY-PEERS | - |
-| 10.255.251.5 | Inherited from peer group MLAG-IPv4-UNDERLAY-PEER | Tenant_A_OP_Zone | - | Inherited from peer group MLAG-IPv4-UNDERLAY-PEER | Inherited from peer group MLAG-IPv4-UNDERLAY-PEER | - | - | - |
+| Neighbor | Remote AS | VRF | Shutdown | Send-community | Maximum-routes | Allowas-in | BFD | RIB Pre-Policy Retain | Route-Reflector Client | Passive |
+| -------- | --------- | --- | -------- | -------------- | -------------- | ---------- | --- | --------------------- | ---------------------- | ------- |
+| 10.255.251.5 | Inherited from peer group MLAG-IPv4-UNDERLAY-PEER | default | - | Inherited from peer group MLAG-IPv4-UNDERLAY-PEER | Inherited from peer group MLAG-IPv4-UNDERLAY-PEER | - | - | - | - | - |
+| 172.30.255.8 | 65001 | default | - | Inherited from peer group IPv4-UNDERLAY-PEERS | Inherited from peer group IPv4-UNDERLAY-PEERS | - | - | - | - | - |
+| 172.30.255.10 | 65001 | default | - | Inherited from peer group IPv4-UNDERLAY-PEERS | Inherited from peer group IPv4-UNDERLAY-PEERS | - | - | - | - | - |
+| 192.0.255.1 | 65001 | default | - | Inherited from peer group EVPN-OVERLAY-PEERS | Inherited from peer group EVPN-OVERLAY-PEERS | - | Inherited from peer group EVPN-OVERLAY-PEERS | - | - | - |
+| 192.0.255.2 | 65001 | default | - | Inherited from peer group EVPN-OVERLAY-PEERS | Inherited from peer group EVPN-OVERLAY-PEERS | - | Inherited from peer group EVPN-OVERLAY-PEERS | - | - | - |
+| 10.255.251.5 | Inherited from peer group MLAG-IPv4-UNDERLAY-PEER | Tenant_A_OP_Zone | - | Inherited from peer group MLAG-IPv4-UNDERLAY-PEER | Inherited from peer group MLAG-IPv4-UNDERLAY-PEER | - | - | - | - | - |
 
-### Router BGP EVPN Address Family
+#### Router BGP EVPN Address Family
 
-#### EVPN Peer Groups
+##### EVPN Peer Groups
 
-| Peer Group | Activate |
-| ---------- | -------- |
-| EVPN-OVERLAY-PEERS | True |
+| Peer Group | Activate | Encapsulation |
+| ---------- | -------- | ------------- |
+| EVPN-OVERLAY-PEERS | True | default |
 
-### Router BGP VLAN Aware Bundles
+#### Router BGP VLAN Aware Bundles
 
 | VLAN Aware Bundle | Route-Distinguisher | Both Route-Target | Import Route Target | Export Route-Target | Redistribute | VLANs |
 | ----------------- | ------------------- | ----------------- | ------------------- | ------------------- | ------------ | ----- |
 | Tenant_A_OP_Zone | 192.0.255.5:10 | 10:10 | - | - | learned | 110 |
 | Tenant_A_VMOTION | 192.0.255.5:55160 | 55160:55160 | - | - | learned | 160 |
 
-### Router BGP VRFs
+#### Router BGP VRFs
 
 | VRF | Route-Distinguisher | Redistribute |
 | --- | ------------------- | ------------ |
 | Tenant_A_OP_Zone | 192.0.255.5:10 | connected |
 
-### Router BGP Device Configuration
+#### Router BGP Device Configuration
 
 ```eos
 !
 router bgp 65102
    router-id 192.0.255.5
-   no bgp default ipv4-unicast
    distance bgp 20 200 200
    graceful-restart restart-time 300
    graceful-restart
    maximum-paths 4 ecmp 4
+   no bgp default ipv4-unicast
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0
    neighbor EVPN-OVERLAY-PEERS bfd
    neighbor EVPN-OVERLAY-PEERS ebgp-multihop 3
-   neighbor EVPN-OVERLAY-PEERS password 7 q+VNViP5i4rVjW1cxFv2wA==
+   neighbor EVPN-OVERLAY-PEERS password 7 <removed>
    neighbor EVPN-OVERLAY-PEERS send-community
    neighbor EVPN-OVERLAY-PEERS maximum-routes 0
    neighbor IPv4-UNDERLAY-PEERS peer group
-   neighbor IPv4-UNDERLAY-PEERS password 7 AQQvKeimxJu+uGQ/yYvv9w==
+   neighbor IPv4-UNDERLAY-PEERS password 7 <removed>
    neighbor IPv4-UNDERLAY-PEERS send-community
    neighbor IPv4-UNDERLAY-PEERS maximum-routes 12000
    neighbor MLAG-IPv4-UNDERLAY-PEER peer group
    neighbor MLAG-IPv4-UNDERLAY-PEER remote-as 65102
    neighbor MLAG-IPv4-UNDERLAY-PEER next-hop-self
    neighbor MLAG-IPv4-UNDERLAY-PEER description leaf4
-   neighbor MLAG-IPv4-UNDERLAY-PEER password 7 vnEaG8gMeQf3d3cN6PktXQ==
+   neighbor MLAG-IPv4-UNDERLAY-PEER password 7 <removed>
    neighbor MLAG-IPv4-UNDERLAY-PEER send-community
    neighbor MLAG-IPv4-UNDERLAY-PEER maximum-routes 12000
    neighbor MLAG-IPv4-UNDERLAY-PEER route-map RM-MLAG-PEER-IN in
@@ -676,17 +669,17 @@ router bgp 65102
       redistribute connected
 ```
 
-# BFD
+## BFD
 
-## Router BFD
+### Router BFD
 
-### Router BFD Multihop Summary
+#### Router BFD Multihop Summary
 
 | Interval | Minimum RX | Multiplier |
 | -------- | ---------- | ---------- |
 | 1200 | 1200 | 3 |
 
-### Router BFD Device Configuration
+#### Router BFD Device Configuration
 
 ```eos
 !
@@ -694,35 +687,35 @@ router bfd
    multihop interval 1200 min-rx 1200 multiplier 3
 ```
 
-# Multicast
+## Multicast
 
-## IP IGMP Snooping
+### IP IGMP Snooping
 
-### IP IGMP Snooping Summary
+#### IP IGMP Snooping Summary
 
 | IGMP Snooping | Fast Leave | Interface Restart Query | Proxy | Restart Query Interval | Robustness Variable |
 | ------------- | ---------- | ----------------------- | ----- | ---------------------- | ------------------- |
 | Enabled | - | - | - | - | - |
 
-### IP IGMP Snooping Device Configuration
+#### IP IGMP Snooping Device Configuration
 
 ```eos
 ```
 
-# Filters
+## Filters
 
-## Prefix-lists
+### Prefix-lists
 
-### Prefix-lists Summary
+#### Prefix-lists Summary
 
-#### PL-LOOPBACKS-EVPN-OVERLAY
+##### PL-LOOPBACKS-EVPN-OVERLAY
 
 | Sequence | Action |
 | -------- | ------ |
 | 10 | permit 192.0.255.0/24 eq 32 |
 | 20 | permit 192.0.254.0/24 eq 32 |
 
-### Prefix-lists Device Configuration
+#### Prefix-lists Device Configuration
 
 ```eos
 !
@@ -731,23 +724,23 @@ ip prefix-list PL-LOOPBACKS-EVPN-OVERLAY
    seq 20 permit 192.0.254.0/24 eq 32
 ```
 
-## Route-maps
+### Route-maps
 
-### Route-maps Summary
+#### Route-maps Summary
 
-#### RM-CONN-2-BGP
+##### RM-CONN-2-BGP
 
 | Sequence | Type | Match | Set | Sub-Route-Map | Continue |
 | -------- | ---- | ----- | --- | ------------- | -------- |
 | 10 | permit | ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY | - | - | - |
 
-#### RM-MLAG-PEER-IN
+##### RM-MLAG-PEER-IN
 
 | Sequence | Type | Match | Set | Sub-Route-Map | Continue |
 | -------- | ---- | ----- | --- | ------------- | -------- |
 | 10 | permit | - | origin incomplete | - | - |
 
-### Route-maps Device Configuration
+#### Route-maps Device Configuration
 
 ```eos
 !
@@ -759,37 +752,32 @@ route-map RM-MLAG-PEER-IN permit 10
    set origin incomplete
 ```
 
-# ACL
+## VRF Instances
 
-# VRF Instances
-
-## VRF Instances Summary
+### VRF Instances Summary
 
 | VRF Name | IP Routing |
 | -------- | ---------- |
-| default | disabled |
 | Tenant_A_OP_Zone | enabled |
 
-## VRF Instances Device Configuration
+### VRF Instances Device Configuration
 
 ```eos
 !
 vrf instance Tenant_A_OP_Zone
 ```
 
-# Virtual Source NAT
+## Virtual Source NAT
 
-## Virtual Source NAT Summary
+### Virtual Source NAT Summary
 
 | Source NAT VRF | Source NAT IP Address |
 | -------------- | --------------------- |
 | Tenant_A_OP_Zone | 10.255.1.5 |
 
-## Virtual Source NAT Configuration
+### Virtual Source NAT Configuration
 
 ```eos
 !
 ip address virtual source-nat vrf Tenant_A_OP_Zone address 10.255.1.5
 ```
-
-# Quality Of Service

--- a/atd-inventory/documentation/devices/leaf4.md
+++ b/atd-inventory/documentation/devices/leaf4.md
@@ -1,13 +1,12 @@
 # leaf4
-# Table of Contents
+
+## Table of Contents
 
 - [Management](#management)
   - [Management Interfaces](#management-interfaces)
   - [DNS Domain](#dns-domain)
-  - [Name Servers](#name-servers)
+  - [IP Name Servers](#ip-name-servers)
   - [Management API HTTP](#management-api-http)
-- [Authentication](#authentication)
-- [Monitoring](#monitoring)
 - [MLAG](#mlag)
   - [MLAG Summary](#mlag-summary)
   - [MLAG Device Configuration](#mlag-device-configuration)
@@ -40,34 +39,32 @@
 - [Filters](#filters)
   - [Prefix-lists](#prefix-lists)
   - [Route-maps](#route-maps)
-- [ACL](#acl)
 - [VRF Instances](#vrf-instances)
   - [VRF Instances Summary](#vrf-instances-summary)
   - [VRF Instances Device Configuration](#vrf-instances-device-configuration)
 - [Virtual Source NAT](#virtual-source-nat)
   - [Virtual Source NAT Summary](#virtual-source-nat-summary)
   - [Virtual Source NAT Configuration](#virtual-source-nat-configuration)
-- [Quality Of Service](#quality-of-service)
 
-# Management
+## Management
 
-## Management Interfaces
+### Management Interfaces
 
-### Management Interfaces Summary
+#### Management Interfaces Summary
 
-#### IPv4
+##### IPv4
 
 | Management Interface | description | Type | VRF | IP Address | Gateway |
 | -------------------- | ----------- | ---- | --- | ---------- | ------- |
 | Management1 | oob_management | oob | default | 192.168.0.15/24 | 192.168.0.1 |
 
-#### IPv6
+##### IPv6
 
 | Management Interface | description | Type | VRF | IPv6 Address | IPv6 Gateway |
 | -------------------- | ----------- | ---- | --- | ------------ | ------------ |
-| Management1 | oob_management | oob | default | -  | - |
+| Management1 | oob_management | oob | default | - | - |
 
-### Management Interfaces Device Configuration
+#### Management Interfaces Device Configuration
 
 ```eos
 !
@@ -77,48 +74,48 @@ interface Management1
    ip address 192.168.0.15/24
 ```
 
-## DNS Domain
+### DNS Domain
 
-### DNS domain: atd.lab
+#### DNS domain: atd.lab
 
-### DNS Domain Device Configuration
+#### DNS Domain Device Configuration
 
 ```eos
 dns domain atd.lab
 !
 ```
 
-## Name Servers
+### IP Name Servers
 
-### Name Servers Summary
+#### IP Name Servers Summary
 
-| Name Server | Source VRF |
-| ----------- | ---------- |
-| 192.168.2.1 | default |
-| 8.8.8.8 | default |
+| Name Server | VRF | Priority |
+| ----------- | --- | -------- |
+| 192.168.2.1 | default | - |
+| 8.8.8.8 | default | - |
 
-### Name Servers Device Configuration
+#### IP Name Servers Device Configuration
 
 ```eos
 ip name-server vrf default 8.8.8.8
 ip name-server vrf default 192.168.2.1
 ```
 
-## Management API HTTP
+### Management API HTTP
 
-### Management API HTTP Summary
+#### Management API HTTP Summary
 
 | HTTP | HTTPS | Default Services |
 | ---- | ----- | ---------------- |
 | False | True | - |
 
-### Management API VRF Access
+#### Management API VRF Access
 
 | VRF Name | IPv4 ACL | IPv6 ACL |
 | -------- | -------- | -------- |
 | default | - | - |
 
-### Management API HTTP Configuration
+#### Management API HTTP Configuration
 
 ```eos
 !
@@ -130,13 +127,9 @@ management api http-commands
       no shutdown
 ```
 
-# Authentication
+## MLAG
 
-# Monitoring
-
-# MLAG
-
-## MLAG Summary
+### MLAG Summary
 
 | Domain-id | Local-interface | Peer-address | Peer-link |
 | --------- | --------------- | ------------ | --------- |
@@ -144,7 +137,7 @@ management api http-commands
 
 Dual primary detection is disabled.
 
-## MLAG Device Configuration
+### MLAG Device Configuration
 
 ```eos
 !
@@ -157,23 +150,23 @@ mlag configuration
    reload-delay non-mlag 330
 ```
 
-# Spanning Tree
+## Spanning Tree
 
-## Spanning Tree Summary
+### Spanning Tree Summary
 
 STP mode: **mstp**
 
-### MSTP Instance and Priority
+#### MSTP Instance and Priority
 
 | Instance(s) | Priority |
 | -------- | -------- |
 | 0 | 16384 |
 
-### Global Spanning-Tree Settings
+#### Global Spanning-Tree Settings
 
 - Spanning Tree disabled for VLANs: **4093-4094**
 
-## Spanning Tree Device Configuration
+### Spanning Tree Device Configuration
 
 ```eos
 !
@@ -182,24 +175,24 @@ no spanning-tree vlan-id 4093-4094
 spanning-tree mst 0 priority 16384
 ```
 
-# Internal VLAN Allocation Policy
+## Internal VLAN Allocation Policy
 
-## Internal VLAN Allocation Policy Summary
+### Internal VLAN Allocation Policy Summary
 
 | Policy Allocation | Range Beginning | Range Ending |
 | ------------------| --------------- | ------------ |
 | ascending | 1006 | 1199 |
 
-## Internal VLAN Allocation Policy Configuration
+### Internal VLAN Allocation Policy Configuration
 
 ```eos
 !
 vlan internal order ascending range 1006 1199
 ```
 
-# VLANs
+## VLANs
 
-## VLANs Summary
+### VLANs Summary
 
 | VLAN ID | Name | Trunk Groups |
 | ------- | ---- | ------------ |
@@ -209,7 +202,7 @@ vlan internal order ascending range 1006 1199
 | 4093 | LEAF_PEER_L3 | LEAF_PEER_L3 |
 | 4094 | MLAG_PEER | MLAG |
 
-## VLANs Device Configuration
+### VLANs Device Configuration
 
 ```eos
 !
@@ -232,31 +225,31 @@ vlan 4094
    trunk group MLAG
 ```
 
-# Interfaces
+## Interfaces
 
-## Ethernet Interfaces
+### Ethernet Interfaces
 
-### Ethernet Interfaces Summary
+#### Ethernet Interfaces Summary
 
-#### L2
+##### L2
 
 | Interface | Description | Mode | VLANs | Native VLAN | Trunk Group | Channel-Group |
 | --------- | ----------- | ---- | ----- | ----------- | ----------- | ------------- |
-| Ethernet1 | MLAG_PEER_leaf3_Ethernet1 | *trunk | *2-4094 | *- | *['LEAF_PEER_L3', 'MLAG'] | 1 |
+| Ethernet1 | MLAG_PEER_leaf3_Ethernet1 | *trunk | *- | *- | *['LEAF_PEER_L3', 'MLAG'] | 1 |
 | Ethernet4 | host2_Eth3 | *access | *110 | *- | *- | 4 |
 | Ethernet5 | host2_Eth4 | *access | *110 | *- | *- | 4 |
-| Ethernet6 | MLAG_PEER_leaf3_Ethernet6 | *trunk | *2-4094 | *- | *['LEAF_PEER_L3', 'MLAG'] | 1 |
+| Ethernet6 | MLAG_PEER_leaf3_Ethernet6 | *trunk | *- | *- | *['LEAF_PEER_L3', 'MLAG'] | 1 |
 
 *Inherited from Port-Channel Interface
 
-#### IPv4
+##### IPv4
 
 | Interface | Description | Type | Channel Group | IP Address | VRF |  MTU | Shutdown | ACL In | ACL Out |
 | --------- | ----------- | -----| ------------- | ---------- | ----| ---- | -------- | ------ | ------- |
 | Ethernet2 | P2P_LINK_TO_SPINE1_Ethernet5 | routed | - | 172.30.255.13/31 | default | 1500 | False | - | - |
 | Ethernet3 | P2P_LINK_TO_SPINE2_Ethernet5 | routed | - | 172.30.255.15/31 | default | 1500 | False | - | - |
 
-### Ethernet Interfaces Device Configuration
+#### Ethernet Interfaces Device Configuration
 
 ```eos
 !
@@ -295,18 +288,18 @@ interface Ethernet6
    channel-group 1 mode active
 ```
 
-## Port-Channel Interfaces
+### Port-Channel Interfaces
 
-### Port-Channel Interfaces Summary
+#### Port-Channel Interfaces Summary
 
-#### L2
+##### L2
 
 | Interface | Description | Type | Mode | VLANs | Native VLAN | Trunk Group | LACP Fallback Timeout | LACP Fallback Mode | MLAG ID | EVPN ESI |
 | --------- | ----------- | ---- | ---- | ----- | ----------- | ------------| --------------------- | ------------------ | ------- | -------- |
-| Port-Channel1 | MLAG_PEER_leaf3_Po1 | switched | trunk | 2-4094 | - | ['LEAF_PEER_L3', 'MLAG'] | - | - | - | - |
+| Port-Channel1 | MLAG_PEER_leaf3_Po1 | switched | trunk | - | - | ['LEAF_PEER_L3', 'MLAG'] | - | - | - | - |
 | Port-Channel4 | host2_PortChannel | switched | access | 110 | - | - | - | - | 4 | - |
 
-### Port-Channel Interfaces Device Configuration
+#### Port-Channel Interfaces Device Configuration
 
 ```eos
 !
@@ -314,7 +307,6 @@ interface Port-Channel1
    description MLAG_PEER_leaf3_Po1
    no shutdown
    switchport
-   switchport trunk allowed vlan 2-4094
    switchport mode trunk
    switchport trunk group LEAF_PEER_L3
    switchport trunk group MLAG
@@ -327,11 +319,11 @@ interface Port-Channel4
    mlag 4
 ```
 
-## Loopback Interfaces
+### Loopback Interfaces
 
-### Loopback Interfaces Summary
+#### Loopback Interfaces Summary
 
-#### IPv4
+##### IPv4
 
 | Interface | Description | VRF | IP Address |
 | --------- | ----------- | --- | ---------- |
@@ -339,7 +331,7 @@ interface Port-Channel4
 | Loopback1 | VTEP_VXLAN_Tunnel_Source | default | 192.0.254.5/32 |
 | Loopback100 | Tenant_A_OP_Zone_VTEP_DIAGNOSTICS | Tenant_A_OP_Zone | 10.255.1.6/32 |
 
-#### IPv6
+##### IPv6
 
 | Interface | Description | VRF | IPv6 Address |
 | --------- | ----------- | --- | ------------ |
@@ -348,7 +340,7 @@ interface Port-Channel4
 | Loopback100 | Tenant_A_OP_Zone_VTEP_DIAGNOSTICS | Tenant_A_OP_Zone | - |
 
 
-### Loopback Interfaces Device Configuration
+#### Loopback Interfaces Device Configuration
 
 ```eos
 !
@@ -369,9 +361,9 @@ interface Loopback100
    ip address 10.255.1.6/32
 ```
 
-## VLAN Interfaces
+### VLAN Interfaces
 
-### VLAN Interfaces Summary
+#### VLAN Interfaces Summary
 
 | Interface | Description | VRF |  MTU | Shutdown |
 | --------- | ----------- | --- | ---- | -------- |
@@ -380,7 +372,7 @@ interface Loopback100
 | Vlan4093 | MLAG_PEER_L3_PEERING | default | 1500 | False |
 | Vlan4094 | MLAG_PEER | default | 1500 | False |
 
-#### IPv4
+##### IPv4
 
 | Interface | VRF | IP Address | IP Address Virtual | IP Router Virtual Address | VRRP | ACL In | ACL Out |
 | --------- | --- | ---------- | ------------------ | ------------------------- | ---- | ------ | ------- |
@@ -389,7 +381,7 @@ interface Loopback100
 | Vlan4093 |  default  |  10.255.251.5/31  |  -  |  -  |  -  |  -  |  -  |
 | Vlan4094 |  default  |  10.255.252.5/31  |  -  |  -  |  -  |  -  |  -  |
 
-### VLAN Interfaces Device Configuration
+#### VLAN Interfaces Device Configuration
 
 ```eos
 !
@@ -420,9 +412,9 @@ interface Vlan4094
    ip address 10.255.252.5/31
 ```
 
-## VXLAN Interface
+### VXLAN Interface
 
-### VXLAN Interface Summary
+#### VXLAN Interface Summary
 
 | Setting | Value |
 | ------- | ----- |
@@ -430,20 +422,20 @@ interface Vlan4094
 | UDP port | 4789 |
 | EVPN MLAG Shared Router MAC | mlag-system-id |
 
-#### VLAN to VNI, Flood List and Multicast Group Mappings
+##### VLAN to VNI, Flood List and Multicast Group Mappings
 
 | VLAN | VNI | Flood List | Multicast Group |
 | ---- | --- | ---------- | --------------- |
 | 110 | 10110 | - | - |
 | 160 | 55160 | - | - |
 
-#### VRF to VNI and Multicast Group Mappings
+##### VRF to VNI and Multicast Group Mappings
 
 | VRF | VNI | Multicast Group |
 | ---- | --- | --------------- |
 | Tenant_A_OP_Zone | 10 | - |
 
-### VXLAN Interface Device Configuration
+#### VXLAN Interface Device Configuration
 
 ```eos
 !
@@ -457,8 +449,9 @@ interface Vxlan1
    vxlan vrf Tenant_A_OP_Zone vni 10
 ```
 
-# Routing
-## Service Routing Protocols Model
+## Routing
+
+### Service Routing Protocols Model
 
 Multi agent routing protocol model enabled
 
@@ -467,39 +460,39 @@ Multi agent routing protocol model enabled
 service routing protocols model multi-agent
 ```
 
-## Virtual Router MAC Address
+### Virtual Router MAC Address
 
-### Virtual Router MAC Address Summary
+#### Virtual Router MAC Address Summary
 
-#### Virtual Router MAC Address: 00:1c:73:00:dc:01
+##### Virtual Router MAC Address: 00:1c:73:00:dc:01
 
-### Virtual Router MAC Address Configuration
+#### Virtual Router MAC Address Configuration
 
 ```eos
 !
 ip virtual-router mac-address 00:1c:73:00:dc:01
 ```
 
-## IP Routing
+### IP Routing
 
-### IP Routing Summary
+#### IP Routing Summary
 
 | VRF | Routing Enabled |
 | --- | --------------- |
 | default | True |
-| default | false |
-| Tenant_A_OP_Zone | true |
+| Tenant_A_OP_Zone | True |
 
-### IP Routing Device Configuration
+#### IP Routing Device Configuration
 
 ```eos
 !
 ip routing
 ip routing vrf Tenant_A_OP_Zone
 ```
-## IPv6 Routing
 
-### IPv6 Routing Summary
+### IPv6 Routing
+
+#### IPv6 Routing Summary
 
 | VRF | Routing Enabled |
 | --- | --------------- |
@@ -507,24 +500,24 @@ ip routing vrf Tenant_A_OP_Zone
 | default | false |
 | Tenant_A_OP_Zone | false |
 
-## Static Routes
+### Static Routes
 
-### Static Routes Summary
+#### Static Routes Summary
 
 | VRF | Destination Prefix | Next Hop IP             | Exit interface      | Administrative Distance       | Tag               | Route Name                    | Metric         |
 | --- | ------------------ | ----------------------- | ------------------- | ----------------------------- | ----------------- | ----------------------------- | -------------- |
 | default | 0.0.0.0/0 | 192.168.0.1 | - | 1 | - | - | - |
 
-### Static Routes Device Configuration
+#### Static Routes Device Configuration
 
 ```eos
 !
 ip route 0.0.0.0/0 192.168.0.1
 ```
 
-## Router BGP
+### Router BGP
 
-### Router BGP Summary
+#### Router BGP Summary
 
 | BGP AS | Router ID |
 | ------ | --------- |
@@ -532,15 +525,15 @@ ip route 0.0.0.0/0 192.168.0.1
 
 | BGP Tuning |
 | ---------- |
-| no bgp default ipv4-unicast |
-| distance bgp 20 200 200 |
 | graceful-restart restart-time 300 |
 | graceful-restart |
+| no bgp default ipv4-unicast |
+| distance bgp 20 200 200 |
 | maximum-paths 4 ecmp 4 |
 
-### Router BGP Peer Groups
+#### Router BGP Peer Groups
 
-#### EVPN-OVERLAY-PEERS
+##### EVPN-OVERLAY-PEERS
 
 | Settings | Value |
 | -------- | ----- |
@@ -551,7 +544,7 @@ ip route 0.0.0.0/0 192.168.0.1
 | Send community | all |
 | Maximum routes | 0 (no limit) |
 
-#### IPv4-UNDERLAY-PEERS
+##### IPv4-UNDERLAY-PEERS
 
 | Settings | Value |
 | -------- | ----- |
@@ -559,7 +552,7 @@ ip route 0.0.0.0/0 192.168.0.1
 | Send community | all |
 | Maximum routes | 12000 |
 
-#### MLAG-IPv4-UNDERLAY-PEER
+##### MLAG-IPv4-UNDERLAY-PEER
 
 | Settings | Value |
 | -------- | ----- |
@@ -569,65 +562,65 @@ ip route 0.0.0.0/0 192.168.0.1
 | Send community | all |
 | Maximum routes | 12000 |
 
-### BGP Neighbors
+#### BGP Neighbors
 
-| Neighbor | Remote AS | VRF | Shutdown | Send-community | Maximum-routes | Allowas-in | BFD | RIB Pre-Policy Retain |
-| -------- | --------- | --- | -------- | -------------- | -------------- | ---------- | --- | --------------------- |
-| 10.255.251.4 | Inherited from peer group MLAG-IPv4-UNDERLAY-PEER | default | - | Inherited from peer group MLAG-IPv4-UNDERLAY-PEER | Inherited from peer group MLAG-IPv4-UNDERLAY-PEER | - | - | - |
-| 172.30.255.12 | 65001 | default | - | Inherited from peer group IPv4-UNDERLAY-PEERS | Inherited from peer group IPv4-UNDERLAY-PEERS | - | - | - |
-| 172.30.255.14 | 65001 | default | - | Inherited from peer group IPv4-UNDERLAY-PEERS | Inherited from peer group IPv4-UNDERLAY-PEERS | - | - | - |
-| 192.0.255.1 | 65001 | default | - | Inherited from peer group EVPN-OVERLAY-PEERS | Inherited from peer group EVPN-OVERLAY-PEERS | - | Inherited from peer group EVPN-OVERLAY-PEERS | - |
-| 192.0.255.2 | 65001 | default | - | Inherited from peer group EVPN-OVERLAY-PEERS | Inherited from peer group EVPN-OVERLAY-PEERS | - | Inherited from peer group EVPN-OVERLAY-PEERS | - |
-| 10.255.251.4 | Inherited from peer group MLAG-IPv4-UNDERLAY-PEER | Tenant_A_OP_Zone | - | Inherited from peer group MLAG-IPv4-UNDERLAY-PEER | Inherited from peer group MLAG-IPv4-UNDERLAY-PEER | - | - | - |
+| Neighbor | Remote AS | VRF | Shutdown | Send-community | Maximum-routes | Allowas-in | BFD | RIB Pre-Policy Retain | Route-Reflector Client | Passive |
+| -------- | --------- | --- | -------- | -------------- | -------------- | ---------- | --- | --------------------- | ---------------------- | ------- |
+| 10.255.251.4 | Inherited from peer group MLAG-IPv4-UNDERLAY-PEER | default | - | Inherited from peer group MLAG-IPv4-UNDERLAY-PEER | Inherited from peer group MLAG-IPv4-UNDERLAY-PEER | - | - | - | - | - |
+| 172.30.255.12 | 65001 | default | - | Inherited from peer group IPv4-UNDERLAY-PEERS | Inherited from peer group IPv4-UNDERLAY-PEERS | - | - | - | - | - |
+| 172.30.255.14 | 65001 | default | - | Inherited from peer group IPv4-UNDERLAY-PEERS | Inherited from peer group IPv4-UNDERLAY-PEERS | - | - | - | - | - |
+| 192.0.255.1 | 65001 | default | - | Inherited from peer group EVPN-OVERLAY-PEERS | Inherited from peer group EVPN-OVERLAY-PEERS | - | Inherited from peer group EVPN-OVERLAY-PEERS | - | - | - |
+| 192.0.255.2 | 65001 | default | - | Inherited from peer group EVPN-OVERLAY-PEERS | Inherited from peer group EVPN-OVERLAY-PEERS | - | Inherited from peer group EVPN-OVERLAY-PEERS | - | - | - |
+| 10.255.251.4 | Inherited from peer group MLAG-IPv4-UNDERLAY-PEER | Tenant_A_OP_Zone | - | Inherited from peer group MLAG-IPv4-UNDERLAY-PEER | Inherited from peer group MLAG-IPv4-UNDERLAY-PEER | - | - | - | - | - |
 
-### Router BGP EVPN Address Family
+#### Router BGP EVPN Address Family
 
-#### EVPN Peer Groups
+##### EVPN Peer Groups
 
-| Peer Group | Activate |
-| ---------- | -------- |
-| EVPN-OVERLAY-PEERS | True |
+| Peer Group | Activate | Encapsulation |
+| ---------- | -------- | ------------- |
+| EVPN-OVERLAY-PEERS | True | default |
 
-### Router BGP VLAN Aware Bundles
+#### Router BGP VLAN Aware Bundles
 
 | VLAN Aware Bundle | Route-Distinguisher | Both Route-Target | Import Route Target | Export Route-Target | Redistribute | VLANs |
 | ----------------- | ------------------- | ----------------- | ------------------- | ------------------- | ------------ | ----- |
 | Tenant_A_OP_Zone | 192.0.255.6:10 | 10:10 | - | - | learned | 110 |
 | Tenant_A_VMOTION | 192.0.255.6:55160 | 55160:55160 | - | - | learned | 160 |
 
-### Router BGP VRFs
+#### Router BGP VRFs
 
 | VRF | Route-Distinguisher | Redistribute |
 | --- | ------------------- | ------------ |
 | Tenant_A_OP_Zone | 192.0.255.6:10 | connected |
 
-### Router BGP Device Configuration
+#### Router BGP Device Configuration
 
 ```eos
 !
 router bgp 65102
    router-id 192.0.255.6
-   no bgp default ipv4-unicast
    distance bgp 20 200 200
    graceful-restart restart-time 300
    graceful-restart
    maximum-paths 4 ecmp 4
+   no bgp default ipv4-unicast
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0
    neighbor EVPN-OVERLAY-PEERS bfd
    neighbor EVPN-OVERLAY-PEERS ebgp-multihop 3
-   neighbor EVPN-OVERLAY-PEERS password 7 q+VNViP5i4rVjW1cxFv2wA==
+   neighbor EVPN-OVERLAY-PEERS password 7 <removed>
    neighbor EVPN-OVERLAY-PEERS send-community
    neighbor EVPN-OVERLAY-PEERS maximum-routes 0
    neighbor IPv4-UNDERLAY-PEERS peer group
-   neighbor IPv4-UNDERLAY-PEERS password 7 AQQvKeimxJu+uGQ/yYvv9w==
+   neighbor IPv4-UNDERLAY-PEERS password 7 <removed>
    neighbor IPv4-UNDERLAY-PEERS send-community
    neighbor IPv4-UNDERLAY-PEERS maximum-routes 12000
    neighbor MLAG-IPv4-UNDERLAY-PEER peer group
    neighbor MLAG-IPv4-UNDERLAY-PEER remote-as 65102
    neighbor MLAG-IPv4-UNDERLAY-PEER next-hop-self
    neighbor MLAG-IPv4-UNDERLAY-PEER description leaf3
-   neighbor MLAG-IPv4-UNDERLAY-PEER password 7 vnEaG8gMeQf3d3cN6PktXQ==
+   neighbor MLAG-IPv4-UNDERLAY-PEER password 7 <removed>
    neighbor MLAG-IPv4-UNDERLAY-PEER send-community
    neighbor MLAG-IPv4-UNDERLAY-PEER maximum-routes 12000
    neighbor MLAG-IPv4-UNDERLAY-PEER route-map RM-MLAG-PEER-IN in
@@ -676,17 +669,17 @@ router bgp 65102
       redistribute connected
 ```
 
-# BFD
+## BFD
 
-## Router BFD
+### Router BFD
 
-### Router BFD Multihop Summary
+#### Router BFD Multihop Summary
 
 | Interval | Minimum RX | Multiplier |
 | -------- | ---------- | ---------- |
 | 1200 | 1200 | 3 |
 
-### Router BFD Device Configuration
+#### Router BFD Device Configuration
 
 ```eos
 !
@@ -694,35 +687,35 @@ router bfd
    multihop interval 1200 min-rx 1200 multiplier 3
 ```
 
-# Multicast
+## Multicast
 
-## IP IGMP Snooping
+### IP IGMP Snooping
 
-### IP IGMP Snooping Summary
+#### IP IGMP Snooping Summary
 
 | IGMP Snooping | Fast Leave | Interface Restart Query | Proxy | Restart Query Interval | Robustness Variable |
 | ------------- | ---------- | ----------------------- | ----- | ---------------------- | ------------------- |
 | Enabled | - | - | - | - | - |
 
-### IP IGMP Snooping Device Configuration
+#### IP IGMP Snooping Device Configuration
 
 ```eos
 ```
 
-# Filters
+## Filters
 
-## Prefix-lists
+### Prefix-lists
 
-### Prefix-lists Summary
+#### Prefix-lists Summary
 
-#### PL-LOOPBACKS-EVPN-OVERLAY
+##### PL-LOOPBACKS-EVPN-OVERLAY
 
 | Sequence | Action |
 | -------- | ------ |
 | 10 | permit 192.0.255.0/24 eq 32 |
 | 20 | permit 192.0.254.0/24 eq 32 |
 
-### Prefix-lists Device Configuration
+#### Prefix-lists Device Configuration
 
 ```eos
 !
@@ -731,23 +724,23 @@ ip prefix-list PL-LOOPBACKS-EVPN-OVERLAY
    seq 20 permit 192.0.254.0/24 eq 32
 ```
 
-## Route-maps
+### Route-maps
 
-### Route-maps Summary
+#### Route-maps Summary
 
-#### RM-CONN-2-BGP
+##### RM-CONN-2-BGP
 
 | Sequence | Type | Match | Set | Sub-Route-Map | Continue |
 | -------- | ---- | ----- | --- | ------------- | -------- |
 | 10 | permit | ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY | - | - | - |
 
-#### RM-MLAG-PEER-IN
+##### RM-MLAG-PEER-IN
 
 | Sequence | Type | Match | Set | Sub-Route-Map | Continue |
 | -------- | ---- | ----- | --- | ------------- | -------- |
 | 10 | permit | - | origin incomplete | - | - |
 
-### Route-maps Device Configuration
+#### Route-maps Device Configuration
 
 ```eos
 !
@@ -759,37 +752,32 @@ route-map RM-MLAG-PEER-IN permit 10
    set origin incomplete
 ```
 
-# ACL
+## VRF Instances
 
-# VRF Instances
-
-## VRF Instances Summary
+### VRF Instances Summary
 
 | VRF Name | IP Routing |
 | -------- | ---------- |
-| default | disabled |
 | Tenant_A_OP_Zone | enabled |
 
-## VRF Instances Device Configuration
+### VRF Instances Device Configuration
 
 ```eos
 !
 vrf instance Tenant_A_OP_Zone
 ```
 
-# Virtual Source NAT
+## Virtual Source NAT
 
-## Virtual Source NAT Summary
+### Virtual Source NAT Summary
 
 | Source NAT VRF | Source NAT IP Address |
 | -------------- | --------------------- |
 | Tenant_A_OP_Zone | 10.255.1.6 |
 
-## Virtual Source NAT Configuration
+### Virtual Source NAT Configuration
 
 ```eos
 !
 ip address virtual source-nat vrf Tenant_A_OP_Zone address 10.255.1.6
 ```
-
-# Quality Of Service

--- a/atd-inventory/documentation/devices/spine1.md
+++ b/atd-inventory/documentation/devices/spine1.md
@@ -1,13 +1,12 @@
 # spine1
-# Table of Contents
+
+## Table of Contents
 
 - [Management](#management)
   - [Management Interfaces](#management-interfaces)
   - [DNS Domain](#dns-domain)
-  - [Name Servers](#name-servers)
+  - [IP Name Servers](#ip-name-servers)
   - [Management API HTTP](#management-api-http)
-- [Authentication](#authentication)
-- [Monitoring](#monitoring)
 - [Spanning Tree](#spanning-tree)
   - [Spanning Tree Summary](#spanning-tree-summary)
   - [Spanning Tree Device Configuration](#spanning-tree-device-configuration)
@@ -25,35 +24,32 @@
   - [Router BGP](#router-bgp)
 - [BFD](#bfd)
   - [Router BFD](#router-bfd)
-- [Multicast](#multicast)
 - [Filters](#filters)
   - [Prefix-lists](#prefix-lists)
   - [Route-maps](#route-maps)
-- [ACL](#acl)
 - [VRF Instances](#vrf-instances)
   - [VRF Instances Summary](#vrf-instances-summary)
   - [VRF Instances Device Configuration](#vrf-instances-device-configuration)
-- [Quality Of Service](#quality-of-service)
 
-# Management
+## Management
 
-## Management Interfaces
+### Management Interfaces
 
-### Management Interfaces Summary
+#### Management Interfaces Summary
 
-#### IPv4
+##### IPv4
 
 | Management Interface | description | Type | VRF | IP Address | Gateway |
 | -------------------- | ----------- | ---- | --- | ---------- | ------- |
 | Management1 | oob_management | oob | default | 192.168.0.10/24 | 192.168.0.1 |
 
-#### IPv6
+##### IPv6
 
 | Management Interface | description | Type | VRF | IPv6 Address | IPv6 Gateway |
 | -------------------- | ----------- | ---- | --- | ------------ | ------------ |
-| Management1 | oob_management | oob | default | -  | - |
+| Management1 | oob_management | oob | default | - | - |
 
-### Management Interfaces Device Configuration
+#### Management Interfaces Device Configuration
 
 ```eos
 !
@@ -63,48 +59,48 @@ interface Management1
    ip address 192.168.0.10/24
 ```
 
-## DNS Domain
+### DNS Domain
 
-### DNS domain: atd.lab
+#### DNS domain: atd.lab
 
-### DNS Domain Device Configuration
+#### DNS Domain Device Configuration
 
 ```eos
 dns domain atd.lab
 !
 ```
 
-## Name Servers
+### IP Name Servers
 
-### Name Servers Summary
+#### IP Name Servers Summary
 
-| Name Server | Source VRF |
-| ----------- | ---------- |
-| 192.168.2.1 | default |
-| 8.8.8.8 | default |
+| Name Server | VRF | Priority |
+| ----------- | --- | -------- |
+| 192.168.2.1 | default | - |
+| 8.8.8.8 | default | - |
 
-### Name Servers Device Configuration
+#### IP Name Servers Device Configuration
 
 ```eos
 ip name-server vrf default 8.8.8.8
 ip name-server vrf default 192.168.2.1
 ```
 
-## Management API HTTP
+### Management API HTTP
 
-### Management API HTTP Summary
+#### Management API HTTP Summary
 
 | HTTP | HTTPS | Default Services |
 | ---- | ----- | ---------------- |
 | False | True | - |
 
-### Management API VRF Access
+#### Management API VRF Access
 
 | VRF Name | IPv4 ACL | IPv6 ACL |
 | -------- | -------- | -------- |
 | default | - | - |
 
-### Management API HTTP Configuration
+#### Management API HTTP Configuration
 
 ```eos
 !
@@ -116,52 +112,48 @@ management api http-commands
       no shutdown
 ```
 
-# Authentication
+## Spanning Tree
 
-# Monitoring
-
-# Spanning Tree
-
-## Spanning Tree Summary
+### Spanning Tree Summary
 
 STP mode: **none**
 
-## Spanning Tree Device Configuration
+### Spanning Tree Device Configuration
 
 ```eos
 !
 spanning-tree mode none
 ```
 
-# Internal VLAN Allocation Policy
+## Internal VLAN Allocation Policy
 
-## Internal VLAN Allocation Policy Summary
+### Internal VLAN Allocation Policy Summary
 
 | Policy Allocation | Range Beginning | Range Ending |
 | ------------------| --------------- | ------------ |
 | ascending | 1006 | 1199 |
 
-## Internal VLAN Allocation Policy Configuration
+### Internal VLAN Allocation Policy Configuration
 
 ```eos
 !
 vlan internal order ascending range 1006 1199
 ```
 
-# Interfaces
+## Interfaces
 
-## Ethernet Interfaces
+### Ethernet Interfaces
 
-### Ethernet Interfaces Summary
+#### Ethernet Interfaces Summary
 
-#### L2
+##### L2
 
 | Interface | Description | Mode | VLANs | Native VLAN | Trunk Group | Channel-Group |
 | --------- | ----------- | ---- | ----- | ----------- | ----------- | ------------- |
 
 *Inherited from Port-Channel Interface
 
-#### IPv4
+##### IPv4
 
 | Interface | Description | Type | Channel Group | IP Address | VRF |  MTU | Shutdown | ACL In | ACL Out |
 | --------- | ----------- | -----| ------------- | ---------- | ----| ---- | -------- | ------ | ------- |
@@ -170,7 +162,7 @@ vlan internal order ascending range 1006 1199
 | Ethernet4 | P2P_LINK_TO_LEAF3_Ethernet2 | routed | - | 172.30.255.8/31 | default | 1500 | False | - | - |
 | Ethernet5 | P2P_LINK_TO_LEAF4_Ethernet2 | routed | - | 172.30.255.12/31 | default | 1500 | False | - | - |
 
-### Ethernet Interfaces Device Configuration
+#### Ethernet Interfaces Device Configuration
 
 ```eos
 !
@@ -203,24 +195,24 @@ interface Ethernet5
    ip address 172.30.255.12/31
 ```
 
-## Loopback Interfaces
+### Loopback Interfaces
 
-### Loopback Interfaces Summary
+#### Loopback Interfaces Summary
 
-#### IPv4
+##### IPv4
 
 | Interface | Description | VRF | IP Address |
 | --------- | ----------- | --- | ---------- |
 | Loopback0 | EVPN_Overlay_Peering | default | 192.0.255.1/32 |
 
-#### IPv6
+##### IPv6
 
 | Interface | Description | VRF | IPv6 Address |
 | --------- | ----------- | --- | ------------ |
 | Loopback0 | EVPN_Overlay_Peering | default | - |
 
 
-### Loopback Interfaces Device Configuration
+#### Loopback Interfaces Device Configuration
 
 ```eos
 !
@@ -230,8 +222,9 @@ interface Loopback0
    ip address 192.0.255.1/32
 ```
 
-# Routing
-## Service Routing Protocols Model
+## Routing
+
+### Service Routing Protocols Model
 
 Multi agent routing protocol model enabled
 
@@ -240,48 +233,48 @@ Multi agent routing protocol model enabled
 service routing protocols model multi-agent
 ```
 
-## IP Routing
+### IP Routing
 
-### IP Routing Summary
+#### IP Routing Summary
 
 | VRF | Routing Enabled |
 | --- | --------------- |
 | default | True |
-| default | false |
 
-### IP Routing Device Configuration
+#### IP Routing Device Configuration
 
 ```eos
 !
 ip routing
 ```
-## IPv6 Routing
 
-### IPv6 Routing Summary
+### IPv6 Routing
+
+#### IPv6 Routing Summary
 
 | VRF | Routing Enabled |
 | --- | --------------- |
 | default | False |
 | default | false |
 
-## Static Routes
+### Static Routes
 
-### Static Routes Summary
+#### Static Routes Summary
 
 | VRF | Destination Prefix | Next Hop IP             | Exit interface      | Administrative Distance       | Tag               | Route Name                    | Metric         |
 | --- | ------------------ | ----------------------- | ------------------- | ----------------------------- | ----------------- | ----------------------------- | -------------- |
 | default | 0.0.0.0/0 | 192.168.0.1 | - | 1 | - | - | - |
 
-### Static Routes Device Configuration
+#### Static Routes Device Configuration
 
 ```eos
 !
 ip route 0.0.0.0/0 192.168.0.1
 ```
 
-## Router BGP
+### Router BGP
 
-### Router BGP Summary
+#### Router BGP Summary
 
 | BGP AS | Router ID |
 | ------ | --------- |
@@ -289,15 +282,15 @@ ip route 0.0.0.0/0 192.168.0.1
 
 | BGP Tuning |
 | ---------- |
-| no bgp default ipv4-unicast |
-| distance bgp 20 200 200 |
 | graceful-restart restart-time 300 |
 | graceful-restart |
+| no bgp default ipv4-unicast |
+| distance bgp 20 200 200 |
 | maximum-paths 4 ecmp 4 |
 
-### Router BGP Peer Groups
+#### Router BGP Peer Groups
 
-#### EVPN-OVERLAY-PEERS
+##### EVPN-OVERLAY-PEERS
 
 | Settings | Value |
 | -------- | ----- |
@@ -309,7 +302,7 @@ ip route 0.0.0.0/0 192.168.0.1
 | Send community | all |
 | Maximum routes | 0 (no limit) |
 
-#### IPv4-UNDERLAY-PEERS
+##### IPv4-UNDERLAY-PEERS
 
 | Settings | Value |
 | -------- | ----- |
@@ -317,48 +310,48 @@ ip route 0.0.0.0/0 192.168.0.1
 | Send community | all |
 | Maximum routes | 12000 |
 
-### BGP Neighbors
+#### BGP Neighbors
 
-| Neighbor | Remote AS | VRF | Shutdown | Send-community | Maximum-routes | Allowas-in | BFD | RIB Pre-Policy Retain |
-| -------- | --------- | --- | -------- | -------------- | -------------- | ---------- | --- | --------------------- |
-| 172.30.255.1 | 65101 | default | - | Inherited from peer group IPv4-UNDERLAY-PEERS | Inherited from peer group IPv4-UNDERLAY-PEERS | - | - | - |
-| 172.30.255.5 | 65101 | default | - | Inherited from peer group IPv4-UNDERLAY-PEERS | Inherited from peer group IPv4-UNDERLAY-PEERS | - | - | - |
-| 172.30.255.9 | 65102 | default | - | Inherited from peer group IPv4-UNDERLAY-PEERS | Inherited from peer group IPv4-UNDERLAY-PEERS | - | - | - |
-| 172.30.255.13 | 65102 | default | - | Inherited from peer group IPv4-UNDERLAY-PEERS | Inherited from peer group IPv4-UNDERLAY-PEERS | - | - | - |
-| 192.0.255.3 | 65101 | default | - | Inherited from peer group EVPN-OVERLAY-PEERS | Inherited from peer group EVPN-OVERLAY-PEERS | - | Inherited from peer group EVPN-OVERLAY-PEERS | - |
-| 192.0.255.4 | 65101 | default | - | Inherited from peer group EVPN-OVERLAY-PEERS | Inherited from peer group EVPN-OVERLAY-PEERS | - | Inherited from peer group EVPN-OVERLAY-PEERS | - |
-| 192.0.255.5 | 65102 | default | - | Inherited from peer group EVPN-OVERLAY-PEERS | Inherited from peer group EVPN-OVERLAY-PEERS | - | Inherited from peer group EVPN-OVERLAY-PEERS | - |
-| 192.0.255.6 | 65102 | default | - | Inherited from peer group EVPN-OVERLAY-PEERS | Inherited from peer group EVPN-OVERLAY-PEERS | - | Inherited from peer group EVPN-OVERLAY-PEERS | - |
+| Neighbor | Remote AS | VRF | Shutdown | Send-community | Maximum-routes | Allowas-in | BFD | RIB Pre-Policy Retain | Route-Reflector Client | Passive |
+| -------- | --------- | --- | -------- | -------------- | -------------- | ---------- | --- | --------------------- | ---------------------- | ------- |
+| 172.30.255.1 | 65101 | default | - | Inherited from peer group IPv4-UNDERLAY-PEERS | Inherited from peer group IPv4-UNDERLAY-PEERS | - | - | - | - | - |
+| 172.30.255.5 | 65101 | default | - | Inherited from peer group IPv4-UNDERLAY-PEERS | Inherited from peer group IPv4-UNDERLAY-PEERS | - | - | - | - | - |
+| 172.30.255.9 | 65102 | default | - | Inherited from peer group IPv4-UNDERLAY-PEERS | Inherited from peer group IPv4-UNDERLAY-PEERS | - | - | - | - | - |
+| 172.30.255.13 | 65102 | default | - | Inherited from peer group IPv4-UNDERLAY-PEERS | Inherited from peer group IPv4-UNDERLAY-PEERS | - | - | - | - | - |
+| 192.0.255.3 | 65101 | default | - | Inherited from peer group EVPN-OVERLAY-PEERS | Inherited from peer group EVPN-OVERLAY-PEERS | - | Inherited from peer group EVPN-OVERLAY-PEERS | - | - | - |
+| 192.0.255.4 | 65101 | default | - | Inherited from peer group EVPN-OVERLAY-PEERS | Inherited from peer group EVPN-OVERLAY-PEERS | - | Inherited from peer group EVPN-OVERLAY-PEERS | - | - | - |
+| 192.0.255.5 | 65102 | default | - | Inherited from peer group EVPN-OVERLAY-PEERS | Inherited from peer group EVPN-OVERLAY-PEERS | - | Inherited from peer group EVPN-OVERLAY-PEERS | - | - | - |
+| 192.0.255.6 | 65102 | default | - | Inherited from peer group EVPN-OVERLAY-PEERS | Inherited from peer group EVPN-OVERLAY-PEERS | - | Inherited from peer group EVPN-OVERLAY-PEERS | - | - | - |
 
-### Router BGP EVPN Address Family
+#### Router BGP EVPN Address Family
 
-#### EVPN Peer Groups
+##### EVPN Peer Groups
 
-| Peer Group | Activate |
-| ---------- | -------- |
-| EVPN-OVERLAY-PEERS | True |
+| Peer Group | Activate | Encapsulation |
+| ---------- | -------- | ------------- |
+| EVPN-OVERLAY-PEERS | True | default |
 
-### Router BGP Device Configuration
+#### Router BGP Device Configuration
 
 ```eos
 !
 router bgp 65001
    router-id 192.0.255.1
-   no bgp default ipv4-unicast
    distance bgp 20 200 200
    graceful-restart restart-time 300
    graceful-restart
    maximum-paths 4 ecmp 4
+   no bgp default ipv4-unicast
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS next-hop-unchanged
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0
    neighbor EVPN-OVERLAY-PEERS bfd
    neighbor EVPN-OVERLAY-PEERS ebgp-multihop 3
-   neighbor EVPN-OVERLAY-PEERS password 7 q+VNViP5i4rVjW1cxFv2wA==
+   neighbor EVPN-OVERLAY-PEERS password 7 <removed>
    neighbor EVPN-OVERLAY-PEERS send-community
    neighbor EVPN-OVERLAY-PEERS maximum-routes 0
    neighbor IPv4-UNDERLAY-PEERS peer group
-   neighbor IPv4-UNDERLAY-PEERS password 7 AQQvKeimxJu+uGQ/yYvv9w==
+   neighbor IPv4-UNDERLAY-PEERS password 7 <removed>
    neighbor IPv4-UNDERLAY-PEERS send-community
    neighbor IPv4-UNDERLAY-PEERS maximum-routes 12000
    neighbor 172.30.255.1 peer group IPv4-UNDERLAY-PEERS
@@ -395,17 +388,17 @@ router bgp 65001
       neighbor IPv4-UNDERLAY-PEERS activate
 ```
 
-# BFD
+## BFD
 
-## Router BFD
+### Router BFD
 
-### Router BFD Multihop Summary
+#### Router BFD Multihop Summary
 
 | Interval | Minimum RX | Multiplier |
 | -------- | ---------- | ---------- |
 | 1200 | 1200 | 3 |
 
-### Router BFD Device Configuration
+#### Router BFD Device Configuration
 
 ```eos
 !
@@ -413,21 +406,19 @@ router bfd
    multihop interval 1200 min-rx 1200 multiplier 3
 ```
 
-# Multicast
+## Filters
 
-# Filters
+### Prefix-lists
 
-## Prefix-lists
+#### Prefix-lists Summary
 
-### Prefix-lists Summary
-
-#### PL-LOOPBACKS-EVPN-OVERLAY
+##### PL-LOOPBACKS-EVPN-OVERLAY
 
 | Sequence | Action |
 | -------- | ------ |
 | 10 | permit 192.0.255.0/24 eq 32 |
 
-### Prefix-lists Device Configuration
+#### Prefix-lists Device Configuration
 
 ```eos
 !
@@ -435,17 +426,17 @@ ip prefix-list PL-LOOPBACKS-EVPN-OVERLAY
    seq 10 permit 192.0.255.0/24 eq 32
 ```
 
-## Route-maps
+### Route-maps
 
-### Route-maps Summary
+#### Route-maps Summary
 
-#### RM-CONN-2-BGP
+##### RM-CONN-2-BGP
 
 | Sequence | Type | Match | Set | Sub-Route-Map | Continue |
 | -------- | ---- | ----- | --- | ------------- | -------- |
 | 10 | permit | ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY | - | - | - |
 
-### Route-maps Device Configuration
+#### Route-maps Device Configuration
 
 ```eos
 !
@@ -453,19 +444,14 @@ route-map RM-CONN-2-BGP permit 10
    match ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY
 ```
 
-# ACL
+## VRF Instances
 
-# VRF Instances
-
-## VRF Instances Summary
+### VRF Instances Summary
 
 | VRF Name | IP Routing |
 | -------- | ---------- |
-| default | disabled |
 
-## VRF Instances Device Configuration
+### VRF Instances Device Configuration
 
 ```eos
 ```
-
-# Quality Of Service

--- a/atd-inventory/documentation/devices/spine2.md
+++ b/atd-inventory/documentation/devices/spine2.md
@@ -1,13 +1,12 @@
 # spine2
-# Table of Contents
+
+## Table of Contents
 
 - [Management](#management)
   - [Management Interfaces](#management-interfaces)
   - [DNS Domain](#dns-domain)
-  - [Name Servers](#name-servers)
+  - [IP Name Servers](#ip-name-servers)
   - [Management API HTTP](#management-api-http)
-- [Authentication](#authentication)
-- [Monitoring](#monitoring)
 - [Spanning Tree](#spanning-tree)
   - [Spanning Tree Summary](#spanning-tree-summary)
   - [Spanning Tree Device Configuration](#spanning-tree-device-configuration)
@@ -25,35 +24,32 @@
   - [Router BGP](#router-bgp)
 - [BFD](#bfd)
   - [Router BFD](#router-bfd)
-- [Multicast](#multicast)
 - [Filters](#filters)
   - [Prefix-lists](#prefix-lists)
   - [Route-maps](#route-maps)
-- [ACL](#acl)
 - [VRF Instances](#vrf-instances)
   - [VRF Instances Summary](#vrf-instances-summary)
   - [VRF Instances Device Configuration](#vrf-instances-device-configuration)
-- [Quality Of Service](#quality-of-service)
 
-# Management
+## Management
 
-## Management Interfaces
+### Management Interfaces
 
-### Management Interfaces Summary
+#### Management Interfaces Summary
 
-#### IPv4
+##### IPv4
 
 | Management Interface | description | Type | VRF | IP Address | Gateway |
 | -------------------- | ----------- | ---- | --- | ---------- | ------- |
 | Management1 | oob_management | oob | default | 192.168.0.11/24 | 192.168.0.1 |
 
-#### IPv6
+##### IPv6
 
 | Management Interface | description | Type | VRF | IPv6 Address | IPv6 Gateway |
 | -------------------- | ----------- | ---- | --- | ------------ | ------------ |
-| Management1 | oob_management | oob | default | -  | - |
+| Management1 | oob_management | oob | default | - | - |
 
-### Management Interfaces Device Configuration
+#### Management Interfaces Device Configuration
 
 ```eos
 !
@@ -63,48 +59,48 @@ interface Management1
    ip address 192.168.0.11/24
 ```
 
-## DNS Domain
+### DNS Domain
 
-### DNS domain: atd.lab
+#### DNS domain: atd.lab
 
-### DNS Domain Device Configuration
+#### DNS Domain Device Configuration
 
 ```eos
 dns domain atd.lab
 !
 ```
 
-## Name Servers
+### IP Name Servers
 
-### Name Servers Summary
+#### IP Name Servers Summary
 
-| Name Server | Source VRF |
-| ----------- | ---------- |
-| 192.168.2.1 | default |
-| 8.8.8.8 | default |
+| Name Server | VRF | Priority |
+| ----------- | --- | -------- |
+| 192.168.2.1 | default | - |
+| 8.8.8.8 | default | - |
 
-### Name Servers Device Configuration
+#### IP Name Servers Device Configuration
 
 ```eos
 ip name-server vrf default 8.8.8.8
 ip name-server vrf default 192.168.2.1
 ```
 
-## Management API HTTP
+### Management API HTTP
 
-### Management API HTTP Summary
+#### Management API HTTP Summary
 
 | HTTP | HTTPS | Default Services |
 | ---- | ----- | ---------------- |
 | False | True | - |
 
-### Management API VRF Access
+#### Management API VRF Access
 
 | VRF Name | IPv4 ACL | IPv6 ACL |
 | -------- | -------- | -------- |
 | default | - | - |
 
-### Management API HTTP Configuration
+#### Management API HTTP Configuration
 
 ```eos
 !
@@ -116,52 +112,48 @@ management api http-commands
       no shutdown
 ```
 
-# Authentication
+## Spanning Tree
 
-# Monitoring
-
-# Spanning Tree
-
-## Spanning Tree Summary
+### Spanning Tree Summary
 
 STP mode: **none**
 
-## Spanning Tree Device Configuration
+### Spanning Tree Device Configuration
 
 ```eos
 !
 spanning-tree mode none
 ```
 
-# Internal VLAN Allocation Policy
+## Internal VLAN Allocation Policy
 
-## Internal VLAN Allocation Policy Summary
+### Internal VLAN Allocation Policy Summary
 
 | Policy Allocation | Range Beginning | Range Ending |
 | ------------------| --------------- | ------------ |
 | ascending | 1006 | 1199 |
 
-## Internal VLAN Allocation Policy Configuration
+### Internal VLAN Allocation Policy Configuration
 
 ```eos
 !
 vlan internal order ascending range 1006 1199
 ```
 
-# Interfaces
+## Interfaces
 
-## Ethernet Interfaces
+### Ethernet Interfaces
 
-### Ethernet Interfaces Summary
+#### Ethernet Interfaces Summary
 
-#### L2
+##### L2
 
 | Interface | Description | Mode | VLANs | Native VLAN | Trunk Group | Channel-Group |
 | --------- | ----------- | ---- | ----- | ----------- | ----------- | ------------- |
 
 *Inherited from Port-Channel Interface
 
-#### IPv4
+##### IPv4
 
 | Interface | Description | Type | Channel Group | IP Address | VRF |  MTU | Shutdown | ACL In | ACL Out |
 | --------- | ----------- | -----| ------------- | ---------- | ----| ---- | -------- | ------ | ------- |
@@ -170,7 +162,7 @@ vlan internal order ascending range 1006 1199
 | Ethernet4 | P2P_LINK_TO_LEAF3_Ethernet3 | routed | - | 172.30.255.10/31 | default | 1500 | False | - | - |
 | Ethernet5 | P2P_LINK_TO_LEAF4_Ethernet3 | routed | - | 172.30.255.14/31 | default | 1500 | False | - | - |
 
-### Ethernet Interfaces Device Configuration
+#### Ethernet Interfaces Device Configuration
 
 ```eos
 !
@@ -203,24 +195,24 @@ interface Ethernet5
    ip address 172.30.255.14/31
 ```
 
-## Loopback Interfaces
+### Loopback Interfaces
 
-### Loopback Interfaces Summary
+#### Loopback Interfaces Summary
 
-#### IPv4
+##### IPv4
 
 | Interface | Description | VRF | IP Address |
 | --------- | ----------- | --- | ---------- |
 | Loopback0 | EVPN_Overlay_Peering | default | 192.0.255.2/32 |
 
-#### IPv6
+##### IPv6
 
 | Interface | Description | VRF | IPv6 Address |
 | --------- | ----------- | --- | ------------ |
 | Loopback0 | EVPN_Overlay_Peering | default | - |
 
 
-### Loopback Interfaces Device Configuration
+#### Loopback Interfaces Device Configuration
 
 ```eos
 !
@@ -230,8 +222,9 @@ interface Loopback0
    ip address 192.0.255.2/32
 ```
 
-# Routing
-## Service Routing Protocols Model
+## Routing
+
+### Service Routing Protocols Model
 
 Multi agent routing protocol model enabled
 
@@ -240,48 +233,48 @@ Multi agent routing protocol model enabled
 service routing protocols model multi-agent
 ```
 
-## IP Routing
+### IP Routing
 
-### IP Routing Summary
+#### IP Routing Summary
 
 | VRF | Routing Enabled |
 | --- | --------------- |
 | default | True |
-| default | false |
 
-### IP Routing Device Configuration
+#### IP Routing Device Configuration
 
 ```eos
 !
 ip routing
 ```
-## IPv6 Routing
 
-### IPv6 Routing Summary
+### IPv6 Routing
+
+#### IPv6 Routing Summary
 
 | VRF | Routing Enabled |
 | --- | --------------- |
 | default | False |
 | default | false |
 
-## Static Routes
+### Static Routes
 
-### Static Routes Summary
+#### Static Routes Summary
 
 | VRF | Destination Prefix | Next Hop IP             | Exit interface      | Administrative Distance       | Tag               | Route Name                    | Metric         |
 | --- | ------------------ | ----------------------- | ------------------- | ----------------------------- | ----------------- | ----------------------------- | -------------- |
 | default | 0.0.0.0/0 | 192.168.0.1 | - | 1 | - | - | - |
 
-### Static Routes Device Configuration
+#### Static Routes Device Configuration
 
 ```eos
 !
 ip route 0.0.0.0/0 192.168.0.1
 ```
 
-## Router BGP
+### Router BGP
 
-### Router BGP Summary
+#### Router BGP Summary
 
 | BGP AS | Router ID |
 | ------ | --------- |
@@ -289,15 +282,15 @@ ip route 0.0.0.0/0 192.168.0.1
 
 | BGP Tuning |
 | ---------- |
-| no bgp default ipv4-unicast |
-| distance bgp 20 200 200 |
 | graceful-restart restart-time 300 |
 | graceful-restart |
+| no bgp default ipv4-unicast |
+| distance bgp 20 200 200 |
 | maximum-paths 4 ecmp 4 |
 
-### Router BGP Peer Groups
+#### Router BGP Peer Groups
 
-#### EVPN-OVERLAY-PEERS
+##### EVPN-OVERLAY-PEERS
 
 | Settings | Value |
 | -------- | ----- |
@@ -309,7 +302,7 @@ ip route 0.0.0.0/0 192.168.0.1
 | Send community | all |
 | Maximum routes | 0 (no limit) |
 
-#### IPv4-UNDERLAY-PEERS
+##### IPv4-UNDERLAY-PEERS
 
 | Settings | Value |
 | -------- | ----- |
@@ -317,48 +310,48 @@ ip route 0.0.0.0/0 192.168.0.1
 | Send community | all |
 | Maximum routes | 12000 |
 
-### BGP Neighbors
+#### BGP Neighbors
 
-| Neighbor | Remote AS | VRF | Shutdown | Send-community | Maximum-routes | Allowas-in | BFD | RIB Pre-Policy Retain |
-| -------- | --------- | --- | -------- | -------------- | -------------- | ---------- | --- | --------------------- |
-| 172.30.255.3 | 65101 | default | - | Inherited from peer group IPv4-UNDERLAY-PEERS | Inherited from peer group IPv4-UNDERLAY-PEERS | - | - | - |
-| 172.30.255.7 | 65101 | default | - | Inherited from peer group IPv4-UNDERLAY-PEERS | Inherited from peer group IPv4-UNDERLAY-PEERS | - | - | - |
-| 172.30.255.11 | 65102 | default | - | Inherited from peer group IPv4-UNDERLAY-PEERS | Inherited from peer group IPv4-UNDERLAY-PEERS | - | - | - |
-| 172.30.255.15 | 65102 | default | - | Inherited from peer group IPv4-UNDERLAY-PEERS | Inherited from peer group IPv4-UNDERLAY-PEERS | - | - | - |
-| 192.0.255.3 | 65101 | default | - | Inherited from peer group EVPN-OVERLAY-PEERS | Inherited from peer group EVPN-OVERLAY-PEERS | - | Inherited from peer group EVPN-OVERLAY-PEERS | - |
-| 192.0.255.4 | 65101 | default | - | Inherited from peer group EVPN-OVERLAY-PEERS | Inherited from peer group EVPN-OVERLAY-PEERS | - | Inherited from peer group EVPN-OVERLAY-PEERS | - |
-| 192.0.255.5 | 65102 | default | - | Inherited from peer group EVPN-OVERLAY-PEERS | Inherited from peer group EVPN-OVERLAY-PEERS | - | Inherited from peer group EVPN-OVERLAY-PEERS | - |
-| 192.0.255.6 | 65102 | default | - | Inherited from peer group EVPN-OVERLAY-PEERS | Inherited from peer group EVPN-OVERLAY-PEERS | - | Inherited from peer group EVPN-OVERLAY-PEERS | - |
+| Neighbor | Remote AS | VRF | Shutdown | Send-community | Maximum-routes | Allowas-in | BFD | RIB Pre-Policy Retain | Route-Reflector Client | Passive |
+| -------- | --------- | --- | -------- | -------------- | -------------- | ---------- | --- | --------------------- | ---------------------- | ------- |
+| 172.30.255.3 | 65101 | default | - | Inherited from peer group IPv4-UNDERLAY-PEERS | Inherited from peer group IPv4-UNDERLAY-PEERS | - | - | - | - | - |
+| 172.30.255.7 | 65101 | default | - | Inherited from peer group IPv4-UNDERLAY-PEERS | Inherited from peer group IPv4-UNDERLAY-PEERS | - | - | - | - | - |
+| 172.30.255.11 | 65102 | default | - | Inherited from peer group IPv4-UNDERLAY-PEERS | Inherited from peer group IPv4-UNDERLAY-PEERS | - | - | - | - | - |
+| 172.30.255.15 | 65102 | default | - | Inherited from peer group IPv4-UNDERLAY-PEERS | Inherited from peer group IPv4-UNDERLAY-PEERS | - | - | - | - | - |
+| 192.0.255.3 | 65101 | default | - | Inherited from peer group EVPN-OVERLAY-PEERS | Inherited from peer group EVPN-OVERLAY-PEERS | - | Inherited from peer group EVPN-OVERLAY-PEERS | - | - | - |
+| 192.0.255.4 | 65101 | default | - | Inherited from peer group EVPN-OVERLAY-PEERS | Inherited from peer group EVPN-OVERLAY-PEERS | - | Inherited from peer group EVPN-OVERLAY-PEERS | - | - | - |
+| 192.0.255.5 | 65102 | default | - | Inherited from peer group EVPN-OVERLAY-PEERS | Inherited from peer group EVPN-OVERLAY-PEERS | - | Inherited from peer group EVPN-OVERLAY-PEERS | - | - | - |
+| 192.0.255.6 | 65102 | default | - | Inherited from peer group EVPN-OVERLAY-PEERS | Inherited from peer group EVPN-OVERLAY-PEERS | - | Inherited from peer group EVPN-OVERLAY-PEERS | - | - | - |
 
-### Router BGP EVPN Address Family
+#### Router BGP EVPN Address Family
 
-#### EVPN Peer Groups
+##### EVPN Peer Groups
 
-| Peer Group | Activate |
-| ---------- | -------- |
-| EVPN-OVERLAY-PEERS | True |
+| Peer Group | Activate | Encapsulation |
+| ---------- | -------- | ------------- |
+| EVPN-OVERLAY-PEERS | True | default |
 
-### Router BGP Device Configuration
+#### Router BGP Device Configuration
 
 ```eos
 !
 router bgp 65001
    router-id 192.0.255.2
-   no bgp default ipv4-unicast
    distance bgp 20 200 200
    graceful-restart restart-time 300
    graceful-restart
    maximum-paths 4 ecmp 4
+   no bgp default ipv4-unicast
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS next-hop-unchanged
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0
    neighbor EVPN-OVERLAY-PEERS bfd
    neighbor EVPN-OVERLAY-PEERS ebgp-multihop 3
-   neighbor EVPN-OVERLAY-PEERS password 7 q+VNViP5i4rVjW1cxFv2wA==
+   neighbor EVPN-OVERLAY-PEERS password 7 <removed>
    neighbor EVPN-OVERLAY-PEERS send-community
    neighbor EVPN-OVERLAY-PEERS maximum-routes 0
    neighbor IPv4-UNDERLAY-PEERS peer group
-   neighbor IPv4-UNDERLAY-PEERS password 7 AQQvKeimxJu+uGQ/yYvv9w==
+   neighbor IPv4-UNDERLAY-PEERS password 7 <removed>
    neighbor IPv4-UNDERLAY-PEERS send-community
    neighbor IPv4-UNDERLAY-PEERS maximum-routes 12000
    neighbor 172.30.255.3 peer group IPv4-UNDERLAY-PEERS
@@ -395,17 +388,17 @@ router bgp 65001
       neighbor IPv4-UNDERLAY-PEERS activate
 ```
 
-# BFD
+## BFD
 
-## Router BFD
+### Router BFD
 
-### Router BFD Multihop Summary
+#### Router BFD Multihop Summary
 
 | Interval | Minimum RX | Multiplier |
 | -------- | ---------- | ---------- |
 | 1200 | 1200 | 3 |
 
-### Router BFD Device Configuration
+#### Router BFD Device Configuration
 
 ```eos
 !
@@ -413,21 +406,19 @@ router bfd
    multihop interval 1200 min-rx 1200 multiplier 3
 ```
 
-# Multicast
+## Filters
 
-# Filters
+### Prefix-lists
 
-## Prefix-lists
+#### Prefix-lists Summary
 
-### Prefix-lists Summary
-
-#### PL-LOOPBACKS-EVPN-OVERLAY
+##### PL-LOOPBACKS-EVPN-OVERLAY
 
 | Sequence | Action |
 | -------- | ------ |
 | 10 | permit 192.0.255.0/24 eq 32 |
 
-### Prefix-lists Device Configuration
+#### Prefix-lists Device Configuration
 
 ```eos
 !
@@ -435,17 +426,17 @@ ip prefix-list PL-LOOPBACKS-EVPN-OVERLAY
    seq 10 permit 192.0.255.0/24 eq 32
 ```
 
-## Route-maps
+### Route-maps
 
-### Route-maps Summary
+#### Route-maps Summary
 
-#### RM-CONN-2-BGP
+##### RM-CONN-2-BGP
 
 | Sequence | Type | Match | Set | Sub-Route-Map | Continue |
 | -------- | ---- | ----- | --- | ------------- | -------- |
 | 10 | permit | ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY | - | - | - |
 
-### Route-maps Device Configuration
+#### Route-maps Device Configuration
 
 ```eos
 !
@@ -453,19 +444,14 @@ route-map RM-CONN-2-BGP permit 10
    match ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY
 ```
 
-# ACL
+## VRF Instances
 
-# VRF Instances
-
-## VRF Instances Summary
+### VRF Instances Summary
 
 | VRF Name | IP Routing |
 | -------- | ---------- |
-| default | disabled |
 
-## VRF Instances Device Configuration
+### VRF Instances Device Configuration
 
 ```eos
 ```
-
-# Quality Of Service

--- a/atd-inventory/group_vars/ATD_FABRIC.yml
+++ b/atd-inventory/group_vars/ATD_FABRIC.yml
@@ -5,7 +5,7 @@
 fabric_name: ATD_FABRIC
 
 # Enable vlan aware bundles
-vxlan_vlan_aware_bundles: true
+evpn_vlan_aware_bundles: true
 
 # Select rfc5549 or ospf, not both
 
@@ -21,31 +21,34 @@ vxlan_vlan_aware_bundles: true
 
 # bgp peer groups passwords
 bgp_peer_groups:
-  IPv4_UNDERLAY_PEERS:
+  ipv4_underlay_peers:
     password: "AQQvKeimxJu+uGQ/yYvv9w=="
-  EVPN_OVERLAY_PEERS:
+  evpn_overlay_peers:
     password: "q+VNViP5i4rVjW1cxFv2wA=="
-  MLAG_IPv4_UNDERLAY_PEER:
+  mlag_ipv4_underlay_peer:
     password: "vnEaG8gMeQf3d3cN6PktXQ=="
+
+bgp_graceful_restart:
+  enabled: true
+  restart_time: 300
+
+bgp_distance:
+  external_routes: 20
+  internal_routes: 200
+  local_routes: 200
 
 # Spine Switches
 spine:
   defaults:
-    platform: vEOS-LAB
+    platform: vEOS-lab
     bgp_as: 65001
     loopback_ipv4_pool: 192.0.255.0/24
     loopback_ipv6_pool: 2001:db8:c01d:c01a::/64
-    bgp_defaults:
-      - 'no bgp default ipv4-unicast'
-      - 'distance bgp 20 200 200'
-      - 'graceful-restart restart-time 300'
-      - 'graceful-restart'
-    mlag: false
   nodes:
-    spine1:
+    - name: spine1
       id: 1
       mgmt_ip: 192.168.0.10/24
-    spine2:
+    - name: spine2
       id: 2
       mgmt_ip: 192.168.0.11/24
 
@@ -55,7 +58,7 @@ spine:
 
 l3leaf:
   defaults:
-    platform: vEOS-LAB
+    platform: vEOS-lab
     loopback_ipv4_pool: 192.0.255.0/24
     loopback_ipv6_pool: 2001:db8:c01d:c01a::/64
     loopback_ipv4_offset: 2
@@ -67,35 +70,30 @@ l3leaf:
     mlag_peer_ipv4_pool: 10.255.252.0/24
     mlag_peer_l3_ipv4_pool: 10.255.251.0/24
     virtual_router_mac_address: 00:1c:73:00:dc:01
-    bgp_defaults:
-      - 'no bgp default ipv4-unicast'
-      - 'distance bgp 20 200 200'
-      - 'graceful-restart restart-time 300'
-      - 'graceful-restart'
     spanning_tree_mode: mstp
     spanning_tree_priority: 16384
     filter:
       # only_vlans_in_use: true
   node_groups:
-    pod1:
+    - group: pod1
       bgp_as: 65101
       nodes:
-        leaf1:
+        - name: leaf1
           id: 1
           mgmt_ip: 192.168.0.12/24
           uplink_switch_interfaces: [Ethernet2, Ethernet2]
-        leaf2:
+        - name: leaf2
           id: 2
           mgmt_ip: 192.168.0.13/24
           uplink_switch_interfaces: [Ethernet3, Ethernet3]
-    pod2:
+    - group: pod2
       bgp_as: 65102
       nodes:
-        leaf3:
+        - name: leaf3
           id: 3
           mgmt_ip: 192.168.0.14/24
           uplink_switch_interfaces: [Ethernet4, Ethernet4]
-        leaf4:
+        - name: leaf4
           id: 4
           mgmt_ip: 192.168.0.15/24
           uplink_switch_interfaces: [Ethernet5, Ethernet5]

--- a/atd-inventory/group_vars/ATD_SERVERS.yml
+++ b/atd-inventory/group_vars/ATD_SERVERS.yml
@@ -1,16 +1,16 @@
 ---
 port_profiles:
-  TENANT_A:
+  - profile: TENANT_A
     mode: access
     vlans: "110"
 
 
 servers:
-  host1:
+  - name: host1
     rack: pod1
     adapters:
       - type: nic
-        server_ports: [Eth1, Eth2, Eth3, Eth4]
+        endpoint_ports: [Eth1, Eth2, Eth3, Eth4]
         switch_ports: [Ethernet4, Ethernet5, Ethernet4, Ethernet5]
         switches: [leaf1,leaf1, leaf2, leaf2]
         profile: TENANT_A
@@ -19,11 +19,11 @@ servers:
           description: PortChannel
           mode: active
 
-  host2:
+  - name: host2
     rack: pod2
     adapters:
       - type: nic
-        server_ports: [Eth1, Eth2, Eth3, Eth4]
+        endpoint_ports: [Eth1, Eth2, Eth3, Eth4]
         switch_ports: [Ethernet4, Ethernet5, Ethernet4, Ethernet5]
         switches: [leaf3, leaf3, leaf4, leaf4]
         profile: TENANT_A

--- a/atd-inventory/group_vars/ATD_SERVERS.yml
+++ b/atd-inventory/group_vars/ATD_SERVERS.yml
@@ -9,26 +9,22 @@ servers:
   - name: host1
     rack: pod1
     adapters:
-      - type: nic
-        endpoint_ports: [Eth1, Eth2, Eth3, Eth4]
+      - endpoint_ports: [Eth1, Eth2, Eth3, Eth4]
         switch_ports: [Ethernet4, Ethernet5, Ethernet4, Ethernet5]
         switches: [leaf1,leaf1, leaf2, leaf2]
         profile: TENANT_A
         port_channel:
-          state: present
           description: PortChannel
           mode: active
 
   - name: host2
     rack: pod2
     adapters:
-      - type: nic
-        endpoint_ports: [Eth1, Eth2, Eth3, Eth4]
+      - endpoint_ports: [Eth1, Eth2, Eth3, Eth4]
         switch_ports: [Ethernet4, Ethernet5, Ethernet4, Ethernet5]
         switches: [leaf3, leaf3, leaf4, leaf4]
         profile: TENANT_A
         port_channel:
-          state: present
           description: PortChannel
           mode: active
 

--- a/atd-inventory/group_vars/ATD_TENANTS_NETWORKS.yml
+++ b/atd-inventory/group_vars/ATD_TENANTS_NETWORKS.yml
@@ -1,21 +1,21 @@
 svi_profiles:
-  GENERIC:
+  - profile: GENERIC
     mtu: 1560
     enabled: true
-  GENERIC_FULL:
+  - profile: GENERIC_FULL
     name: GENERIC Name
     mtu: 1560
     enabled: false
     ip_address_virtual: 10.1.10.254/24
-  WITH_NO_MTU:
+  - profile: WITH_NO_MTU
     enabled: true
-  WITH_SNOOPING:
+  - profile: WITH_SNOOPING
     enabled: true
     igmp_snooping_enabled: false
 
 tenants:
   # Tenant A Specific Information - VRFs / VLANs
-  Tenant_A:
+  - name: Tenant_A
     mac_vrf_vni_base: 10000
     # Optional example enabling multicast for tenant
     # Requires enabling of multicast in ATD_FABRIC.yml
@@ -24,34 +24,34 @@ tenants:
     #   underlay_l2_multicast_group_ipv4_pool: 232.0.0.0/20
     #   underlay_l2_multicast_group_ipv4_pool_offset: 2
     vrfs:
-      Tenant_A_OP_Zone:
+      - name: Tenant_A_OP_Zone
         vrf_vni: 10
         vtep_diagnostic:
           loopback: 100
           loopback_ip_range: 10.255.1.0/24
         svis:
-          110:
+          - id: 110
             name: Tenant_A_OP_Zone_1
             tags: [opzone]
             enabled: true
             ip_address_virtual: 10.1.10.1/24
     l2vlans:
-      160:
+      - id: 160
         vni_override: 55160
         name: Tenant_A_VMOTION
         tags: [vmotion]
   # Tenant_B:
   #   mac_vrf_vni_base: 20000
-  #   vrfs:
+  #   - name: vrfs
   #     Tenant_B_OP_Zone:
   #       vrf_vni: 20
   #       svis:
-  #         210:
+  #         - id: 210
   #           name: Tenant_B_OP_Zone_1
   #           tags: ['opzone']
   #           profile: WITH_NO_MTU
   #           ip_address_virtual: 10.2.10.1/24
-  #         211:
+  #         - id: 211
   #           name: Tenant_B_OP_Zone_2
   #           tags: ['opzone']
   #           profile: GENERIC_FULL

--- a/atd-inventory/group_vars/ATD_TENANTS_NETWORKS.yml
+++ b/atd-inventory/group_vars/ATD_TENANTS_NETWORKS.yml
@@ -40,10 +40,10 @@ tenants:
         vni_override: 55160
         name: Tenant_A_VMOTION
         tags: [vmotion]
-  # Tenant_B:
+  # - name: Tenant_B
   #   mac_vrf_vni_base: 20000
-  #   - name: vrfs
-  #     Tenant_B_OP_Zone:
+  #   vrfs:
+  #     - name: Tenant_B_OP_Zone
   #       vrf_vni: 20
   #       svis:
   #         - id: 210

--- a/atd-inventory/intended/configs/leaf1.cfg
+++ b/atd-inventory/intended/configs/leaf1.cfg
@@ -42,7 +42,6 @@ interface Port-Channel1
    description MLAG_PEER_leaf2_Po1
    no shutdown
    switchport
-   switchport trunk allowed vlan 2-4094
    switchport mode trunk
    switchport trunk group LEAF_PEER_L3
    switchport trunk group MLAG
@@ -177,11 +176,11 @@ router bfd
 !
 router bgp 65101
    router-id 192.0.255.3
-   no bgp default ipv4-unicast
    distance bgp 20 200 200
    graceful-restart restart-time 300
    graceful-restart
    maximum-paths 4 ecmp 4
+   no bgp default ipv4-unicast
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0
    neighbor EVPN-OVERLAY-PEERS bfd

--- a/atd-inventory/intended/configs/leaf2.cfg
+++ b/atd-inventory/intended/configs/leaf2.cfg
@@ -42,7 +42,6 @@ interface Port-Channel1
    description MLAG_PEER_leaf1_Po1
    no shutdown
    switchport
-   switchport trunk allowed vlan 2-4094
    switchport mode trunk
    switchport trunk group LEAF_PEER_L3
    switchport trunk group MLAG
@@ -177,11 +176,11 @@ router bfd
 !
 router bgp 65101
    router-id 192.0.255.4
-   no bgp default ipv4-unicast
    distance bgp 20 200 200
    graceful-restart restart-time 300
    graceful-restart
    maximum-paths 4 ecmp 4
+   no bgp default ipv4-unicast
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0
    neighbor EVPN-OVERLAY-PEERS bfd

--- a/atd-inventory/intended/configs/leaf3.cfg
+++ b/atd-inventory/intended/configs/leaf3.cfg
@@ -42,7 +42,6 @@ interface Port-Channel1
    description MLAG_PEER_leaf4_Po1
    no shutdown
    switchport
-   switchport trunk allowed vlan 2-4094
    switchport mode trunk
    switchport trunk group LEAF_PEER_L3
    switchport trunk group MLAG
@@ -177,11 +176,11 @@ router bfd
 !
 router bgp 65102
    router-id 192.0.255.5
-   no bgp default ipv4-unicast
    distance bgp 20 200 200
    graceful-restart restart-time 300
    graceful-restart
    maximum-paths 4 ecmp 4
+   no bgp default ipv4-unicast
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0
    neighbor EVPN-OVERLAY-PEERS bfd

--- a/atd-inventory/intended/configs/leaf4.cfg
+++ b/atd-inventory/intended/configs/leaf4.cfg
@@ -42,7 +42,6 @@ interface Port-Channel1
    description MLAG_PEER_leaf3_Po1
    no shutdown
    switchport
-   switchport trunk allowed vlan 2-4094
    switchport mode trunk
    switchport trunk group LEAF_PEER_L3
    switchport trunk group MLAG
@@ -177,11 +176,11 @@ router bfd
 !
 router bgp 65102
    router-id 192.0.255.6
-   no bgp default ipv4-unicast
    distance bgp 20 200 200
    graceful-restart restart-time 300
    graceful-restart
    maximum-paths 4 ecmp 4
+   no bgp default ipv4-unicast
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0
    neighbor EVPN-OVERLAY-PEERS bfd

--- a/atd-inventory/intended/configs/spine1.cfg
+++ b/atd-inventory/intended/configs/spine1.cfg
@@ -69,11 +69,11 @@ router bfd
 !
 router bgp 65001
    router-id 192.0.255.1
-   no bgp default ipv4-unicast
    distance bgp 20 200 200
    graceful-restart restart-time 300
    graceful-restart
    maximum-paths 4 ecmp 4
+   no bgp default ipv4-unicast
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS next-hop-unchanged
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0

--- a/atd-inventory/intended/configs/spine2.cfg
+++ b/atd-inventory/intended/configs/spine2.cfg
@@ -69,11 +69,11 @@ router bfd
 !
 router bgp 65001
    router-id 192.0.255.2
-   no bgp default ipv4-unicast
    distance bgp 20 200 200
    graceful-restart restart-time 300
    graceful-restart
    maximum-paths 4 ecmp 4
+   no bgp default ipv4-unicast
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS next-hop-unchanged
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0

--- a/atd-inventory/intended/structured_configs/leaf1.yml
+++ b/atd-inventory/intended/structured_configs/leaf1.yml
@@ -1,104 +1,113 @@
 router_bgp:
   as: '65101'
   router_id: 192.0.255.3
-  bgp_defaults:
-  - no bgp default ipv4-unicast
-  - distance bgp 20 200 200
-  - graceful-restart restart-time 300
-  - graceful-restart
-  - maximum-paths 4 ecmp 4
+  distance:
+    external_routes: 20
+    internal_routes: 200
+    local_routes: 200
+  bgp:
+    default:
+      ipv4_unicast: false
+  maximum_paths:
+    paths: 4
+    ecmp: 4
+  graceful_restart:
+    enabled: true
+    restart_time: 300
   peer_groups:
-    MLAG-IPv4-UNDERLAY-PEER:
-      type: ipv4
-      remote_as: '65101'
-      next_hop_self: true
-      description: leaf2
-      password: vnEaG8gMeQf3d3cN6PktXQ==
-      maximum_routes: 12000
-      send_community: all
-      route_map_in: RM-MLAG-PEER-IN
-    IPv4-UNDERLAY-PEERS:
-      type: ipv4
-      password: AQQvKeimxJu+uGQ/yYvv9w==
-      maximum_routes: 12000
-      send_community: all
-    EVPN-OVERLAY-PEERS:
-      type: evpn
-      update_source: Loopback0
-      bfd: true
-      ebgp_multihop: '3'
-      password: q+VNViP5i4rVjW1cxFv2wA==
-      send_community: all
-      maximum_routes: 0
+  - name: MLAG-IPv4-UNDERLAY-PEER
+    type: ipv4
+    remote_as: '65101'
+    next_hop_self: true
+    description: leaf2
+    password: vnEaG8gMeQf3d3cN6PktXQ==
+    maximum_routes: 12000
+    send_community: all
+    route_map_in: RM-MLAG-PEER-IN
+  - name: IPv4-UNDERLAY-PEERS
+    type: ipv4
+    password: AQQvKeimxJu+uGQ/yYvv9w==
+    maximum_routes: 12000
+    send_community: all
+  - name: EVPN-OVERLAY-PEERS
+    type: evpn
+    update_source: Loopback0
+    bfd: true
+    password: q+VNViP5i4rVjW1cxFv2wA==
+    send_community: all
+    maximum_routes: 0
+    ebgp_multihop: 3
   address_family_ipv4:
     peer_groups:
-      MLAG-IPv4-UNDERLAY-PEER:
-        activate: true
-      IPv4-UNDERLAY-PEERS:
-        activate: true
-      EVPN-OVERLAY-PEERS:
-        activate: false
+    - name: MLAG-IPv4-UNDERLAY-PEER
+      activate: true
+    - name: IPv4-UNDERLAY-PEERS
+      activate: true
+    - name: EVPN-OVERLAY-PEERS
+      activate: false
   neighbors:
-    10.255.251.1:
-      peer_group: MLAG-IPv4-UNDERLAY-PEER
-      description: leaf2
-    172.30.255.0:
-      peer_group: IPv4-UNDERLAY-PEERS
-      remote_as: '65001'
-      description: spine1_Ethernet2
-    172.30.255.2:
-      peer_group: IPv4-UNDERLAY-PEERS
-      remote_as: '65001'
-      description: spine2_Ethernet2
-    192.0.255.1:
-      peer_group: EVPN-OVERLAY-PEERS
-      description: spine1
-      remote_as: '65001'
-    192.0.255.2:
-      peer_group: EVPN-OVERLAY-PEERS
-      description: spine2
-      remote_as: '65001'
+  - ip_address: 10.255.251.1
+    peer_group: MLAG-IPv4-UNDERLAY-PEER
+    description: leaf2
+  - ip_address: 172.30.255.0
+    peer_group: IPv4-UNDERLAY-PEERS
+    remote_as: '65001'
+    description: spine1_Ethernet2
+  - ip_address: 172.30.255.2
+    peer_group: IPv4-UNDERLAY-PEERS
+    remote_as: '65001'
+    description: spine2_Ethernet2
+  - ip_address: 192.0.255.1
+    peer_group: EVPN-OVERLAY-PEERS
+    description: spine1
+    remote_as: '65001'
+  - ip_address: 192.0.255.2
+    peer_group: EVPN-OVERLAY-PEERS
+    description: spine2
+    remote_as: '65001'
   redistribute_routes:
-    connected:
-      route_map: RM-CONN-2-BGP
+  - source_protocol: connected
+    route_map: RM-CONN-2-BGP
   address_family_evpn:
     peer_groups:
-      EVPN-OVERLAY-PEERS:
-        activate: true
+    - name: EVPN-OVERLAY-PEERS
+      activate: true
   vrfs:
-    Tenant_A_OP_Zone:
-      router_id: 192.0.255.3
-      rd: 192.0.255.3:10
-      route_targets:
-        import:
-          evpn:
-          - '10:10'
-        export:
-          evpn:
-          - '10:10'
-      neighbors:
-        10.255.251.1:
-          peer_group: MLAG-IPv4-UNDERLAY-PEER
-      redistribute_routes:
-      - connected
-  vlan_aware_bundles:
-    Tenant_A_OP_Zone:
-      rd: 192.0.255.3:10
-      route_targets:
-        both:
+  - name: Tenant_A_OP_Zone
+    router_id: 192.0.255.3
+    rd: 192.0.255.3:10
+    route_targets:
+      import:
+      - address_family: evpn
+        route_targets:
         - '10:10'
-      redistribute_routes:
-      - learned
-      vlan: 110
-    Tenant_A_VMOTION:
-      tenant: Tenant_A
-      rd: 192.0.255.3:55160
-      route_targets:
-        both:
-        - 55160:55160
-      redistribute_routes:
-      - learned
-      vlan: 160
+      export:
+      - address_family: evpn
+        route_targets:
+        - '10:10'
+    redistribute_routes:
+    - source_protocol: connected
+    neighbors:
+    - ip_address: 10.255.251.1
+      peer_group: MLAG-IPv4-UNDERLAY-PEER
+  vlan_aware_bundles:
+  - name: Tenant_A_OP_Zone
+    rd: 192.0.255.3:10
+    route_targets:
+      both:
+      - '10:10'
+    redistribute_routes:
+    - learned
+    vlan: '110'
+  - name: Tenant_A_VMOTION
+    tenant: Tenant_A
+    rd: 192.0.255.3:55160
+    route_targets:
+      both:
+      - 55160:55160
+    redistribute_routes:
+    - learned
+    vlan: '160'
 static_routes:
 - vrf: default
   destination_address_prefix: 0.0.0.0/0
@@ -110,208 +119,204 @@ vlan_internal_order:
   range:
     beginning: 1006
     ending: 1199
-name_server:
-  source:
-    vrf: default
-  nodes:
-  - 192.168.2.1
-  - 8.8.8.8
+ip_name_servers:
+- ip_address: 192.168.2.1
+  vrf: default
+- ip_address: 8.8.8.8
+  vrf: default
 spanning_tree:
   mode: mstp
   mst_instances:
-    '0':
-      priority: 16384
+  - id: '0'
+    priority: 16384
   no_spanning_tree_vlan: 4093-4094
 vrfs:
-  default:
-    ip_routing: false
-  Tenant_A_OP_Zone:
-    tenant: Tenant_A
-    ip_routing: true
+- name: default
+  ip_routing: false
+- name: Tenant_A_OP_Zone
+  tenant: Tenant_A
+  ip_routing: true
 management_interfaces:
-  Management1:
-    description: oob_management
-    shutdown: false
-    vrf: default
-    ip_address: 192.168.0.12/24
-    gateway: 192.168.0.1
-    type: oob
+- name: Management1
+  description: oob_management
+  shutdown: false
+  vrf: default
+  ip_address: 192.168.0.12/24
+  gateway: 192.168.0.1
+  type: oob
 management_api_http:
   enable_vrfs:
-    default: {}
+  - name: default
   enable_https: true
 vlans:
-  4093:
-    tenant: system
-    name: LEAF_PEER_L3
-    trunk_groups:
-    - LEAF_PEER_L3
-  4094:
-    tenant: system
-    name: MLAG_PEER
-    trunk_groups:
-    - MLAG
-  110:
-    tenant: Tenant_A
-    name: Tenant_A_OP_Zone_1
-  3009:
-    tenant: Tenant_A
-    name: MLAG_iBGP_Tenant_A_OP_Zone
-    trunk_groups:
-    - LEAF_PEER_L3
-  160:
-    tenant: Tenant_A
-    name: Tenant_A_VMOTION
+- id: 4093
+  tenant: system
+  name: LEAF_PEER_L3
+  trunk_groups:
+  - LEAF_PEER_L3
+- id: 4094
+  tenant: system
+  name: MLAG_PEER
+  trunk_groups:
+  - MLAG
+- id: 110
+  name: Tenant_A_OP_Zone_1
+  tenant: Tenant_A
+- id: 3009
+  name: MLAG_iBGP_Tenant_A_OP_Zone
+  trunk_groups:
+  - LEAF_PEER_L3
+  tenant: Tenant_A
+- id: 160
+  name: Tenant_A_VMOTION
+  tenant: Tenant_A
 vlan_interfaces:
-  Vlan4093:
-    description: MLAG_PEER_L3_PEERING
-    shutdown: false
-    mtu: 1500
-    ip_address: 10.255.251.0/31
-  Vlan4094:
-    description: MLAG_PEER
-    shutdown: false
-    ip_address: 10.255.252.0/31
-    no_autostate: true
-    mtu: 1500
-  Vlan110:
-    tenant: Tenant_A
-    tags:
-    - opzone
-    description: Tenant_A_OP_Zone_1
-    shutdown: false
-    vrf: Tenant_A_OP_Zone
-    ip_address_virtual: 10.1.10.1/24
-  Vlan3009:
-    tenant: Tenant_A
-    type: underlay_peering
-    shutdown: false
-    description: 'MLAG_PEER_L3_iBGP: vrf Tenant_A_OP_Zone'
-    vrf: Tenant_A_OP_Zone
-    ip_address: 10.255.251.0/31
-    mtu: 1500
+- name: Vlan4093
+  description: MLAG_PEER_L3_PEERING
+  shutdown: false
+  mtu: 1500
+  ip_address: 10.255.251.0/31
+- name: Vlan4094
+  description: MLAG_PEER
+  shutdown: false
+  ip_address: 10.255.252.0/31
+  no_autostate: true
+  mtu: 1500
+- name: Vlan110
+  tenant: Tenant_A
+  tags:
+  - opzone
+  description: Tenant_A_OP_Zone_1
+  shutdown: false
+  ip_address_virtual: 10.1.10.1/24
+  vrf: Tenant_A_OP_Zone
+- name: Vlan3009
+  tenant: Tenant_A
+  type: underlay_peering
+  shutdown: false
+  description: 'MLAG_PEER_L3_iBGP: vrf Tenant_A_OP_Zone'
+  vrf: Tenant_A_OP_Zone
+  mtu: 1500
+  ip_address: 10.255.251.0/31
 port_channel_interfaces:
-  Port-Channel1:
-    description: MLAG_PEER_leaf2_Po1
-    type: switched
-    shutdown: false
-    vlans: 2-4094
-    mode: trunk
-    trunk_groups:
-    - LEAF_PEER_L3
-    - MLAG
-  Port-Channel4:
-    description: host1_PortChannel
-    type: switched
-    shutdown: false
-    mode: access
-    vlans: 110
-    mlag: 4
+- name: Port-Channel1
+  description: MLAG_PEER_leaf2_Po1
+  type: switched
+  shutdown: false
+  mode: trunk
+  trunk_groups:
+  - LEAF_PEER_L3
+  - MLAG
+- name: Port-Channel4
+  description: host1_PortChannel
+  type: switched
+  shutdown: false
+  mode: access
+  vlans: '110'
+  mlag: 4
 ethernet_interfaces:
-  Ethernet1:
-    peer: leaf2
-    peer_interface: Ethernet1
-    peer_type: mlag_peer
-    description: MLAG_PEER_leaf2_Ethernet1
-    type: switched
-    shutdown: false
-    channel_group:
-      id: 1
-      mode: active
-  Ethernet6:
-    peer: leaf2
-    peer_interface: Ethernet6
-    peer_type: mlag_peer
-    description: MLAG_PEER_leaf2_Ethernet6
-    type: switched
-    shutdown: false
-    channel_group:
-      id: 1
-      mode: active
-  Ethernet2:
-    peer: spine1
-    peer_interface: Ethernet2
-    peer_type: spine
-    description: P2P_LINK_TO_SPINE1_Ethernet2
-    mtu: 1500
-    type: routed
-    shutdown: false
-    ip_address: 172.30.255.1/31
-  Ethernet3:
-    peer: spine2
-    peer_interface: Ethernet2
-    peer_type: spine
-    description: P2P_LINK_TO_SPINE2_Ethernet2
-    mtu: 1500
-    type: routed
-    shutdown: false
-    ip_address: 172.30.255.3/31
-  Ethernet4:
-    peer: host1
-    peer_interface: Eth1
-    peer_type: server
-    description: host1_Eth1
-    type: switched
-    shutdown: false
-    mode: access
-    vlans: 110
-    channel_group:
-      id: 4
-      mode: active
-  Ethernet5:
-    peer: host1
-    peer_interface: Eth2
-    peer_type: server
-    description: host1_Eth2
-    type: switched
-    shutdown: false
-    mode: access
-    vlans: 110
-    channel_group:
-      id: 4
-      mode: active
+- name: Ethernet1
+  peer: leaf2
+  peer_interface: Ethernet1
+  peer_type: mlag_peer
+  description: MLAG_PEER_leaf2_Ethernet1
+  type: port-channel-member
+  shutdown: false
+  channel_group:
+    id: 1
+    mode: active
+- name: Ethernet6
+  peer: leaf2
+  peer_interface: Ethernet6
+  peer_type: mlag_peer
+  description: MLAG_PEER_leaf2_Ethernet6
+  type: port-channel-member
+  shutdown: false
+  channel_group:
+    id: 1
+    mode: active
+- name: Ethernet2
+  peer: spine1
+  peer_interface: Ethernet2
+  peer_type: spine
+  description: P2P_LINK_TO_SPINE1_Ethernet2
+  shutdown: false
+  mtu: 1500
+  type: routed
+  ip_address: 172.30.255.1/31
+- name: Ethernet3
+  peer: spine2
+  peer_interface: Ethernet2
+  peer_type: spine
+  description: P2P_LINK_TO_SPINE2_Ethernet2
+  shutdown: false
+  mtu: 1500
+  type: routed
+  ip_address: 172.30.255.3/31
+- name: Ethernet4
+  peer: host1
+  peer_interface: Eth1
+  peer_type: server
+  port_profile: TENANT_A
+  description: host1_Eth1
+  shutdown: false
+  type: port-channel-member
+  channel_group:
+    id: 4
+    mode: active
+- name: Ethernet5
+  peer: host1
+  peer_interface: Eth2
+  peer_type: server
+  port_profile: TENANT_A
+  description: host1_Eth2
+  shutdown: false
+  type: port-channel-member
+  channel_group:
+    id: 4
+    mode: active
 mlag_configuration:
   domain_id: pod1
   local_interface: Vlan4094
   peer_address: 10.255.252.1
   peer_link: Port-Channel1
-  reload_delay_mlag: 300
-  reload_delay_non_mlag: 330
+  reload_delay_mlag: '300'
+  reload_delay_non_mlag: '330'
 route_maps:
-  RM-MLAG-PEER-IN:
-    sequence_numbers:
-      10:
-        type: permit
-        set:
-        - origin incomplete
-        description: Make routes learned over MLAG Peer-link less preferred on spines to ensure optimal routing
-  RM-CONN-2-BGP:
-    sequence_numbers:
-      10:
-        type: permit
-        match:
-        - ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY
+- name: RM-MLAG-PEER-IN
+  sequence_numbers:
+  - sequence: 10
+    type: permit
+    set:
+    - origin incomplete
+    description: Make routes learned over MLAG Peer-link less preferred on spines to ensure optimal routing
+- name: RM-CONN-2-BGP
+  sequence_numbers:
+  - sequence: 10
+    type: permit
+    match:
+    - ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY
 loopback_interfaces:
-  Loopback0:
-    description: EVPN_Overlay_Peering
-    shutdown: false
-    ip_address: 192.0.255.3/32
-  Loopback1:
-    description: VTEP_VXLAN_Tunnel_Source
-    shutdown: false
-    ip_address: 192.0.254.3/32
-  Loopback100:
-    description: Tenant_A_OP_Zone_VTEP_DIAGNOSTICS
-    shutdown: false
-    vrf: Tenant_A_OP_Zone
-    ip_address: 10.255.1.3/32
+- name: Loopback0
+  description: EVPN_Overlay_Peering
+  shutdown: false
+  ip_address: 192.0.255.3/32
+- name: Loopback1
+  description: VTEP_VXLAN_Tunnel_Source
+  shutdown: false
+  ip_address: 192.0.254.3/32
+- name: Loopback100
+  description: Tenant_A_OP_Zone_VTEP_DIAGNOSTICS
+  shutdown: false
+  vrf: Tenant_A_OP_Zone
+  ip_address: 10.255.1.3/32
 prefix_lists:
-  PL-LOOPBACKS-EVPN-OVERLAY:
-    sequence_numbers:
-      10:
-        action: permit 192.0.255.0/24 eq 32
-      20:
-        action: permit 192.0.254.0/24 eq 32
+- name: PL-LOOPBACKS-EVPN-OVERLAY
+  sequence_numbers:
+  - sequence: 10
+    action: permit 192.0.255.0/24 eq 32
+  - sequence: 20
+    action: permit 192.0.254.0/24 eq 32
 router_bfd:
   multihop:
     interval: 1200
@@ -324,17 +329,17 @@ vxlan_interface:
   Vxlan1:
     description: leaf1_VTEP
     vxlan:
+      udp_port: 4789
       source_interface: Loopback1
       virtual_router_encapsulation_mac_address: mlag-system-id
-      udp_port: 4789
       vlans:
-        110:
-          vni: 10110
-        160:
-          vni: 55160
+      - id: 110
+        vni: 10110
+      - id: 160
+        vni: 55160
       vrfs:
-        Tenant_A_OP_Zone:
-          vni: 10
+      - name: Tenant_A_OP_Zone
+        vni: 10
 virtual_source_nat_vrfs:
-  Tenant_A_OP_Zone:
-    ip_address: 10.255.1.3
+- name: Tenant_A_OP_Zone
+  ip_address: 10.255.1.3

--- a/atd-inventory/intended/structured_configs/leaf2.yml
+++ b/atd-inventory/intended/structured_configs/leaf2.yml
@@ -1,104 +1,113 @@
 router_bgp:
   as: '65101'
   router_id: 192.0.255.4
-  bgp_defaults:
-  - no bgp default ipv4-unicast
-  - distance bgp 20 200 200
-  - graceful-restart restart-time 300
-  - graceful-restart
-  - maximum-paths 4 ecmp 4
+  distance:
+    external_routes: 20
+    internal_routes: 200
+    local_routes: 200
+  bgp:
+    default:
+      ipv4_unicast: false
+  maximum_paths:
+    paths: 4
+    ecmp: 4
+  graceful_restart:
+    enabled: true
+    restart_time: 300
   peer_groups:
-    MLAG-IPv4-UNDERLAY-PEER:
-      type: ipv4
-      remote_as: '65101'
-      next_hop_self: true
-      description: leaf1
-      password: vnEaG8gMeQf3d3cN6PktXQ==
-      maximum_routes: 12000
-      send_community: all
-      route_map_in: RM-MLAG-PEER-IN
-    IPv4-UNDERLAY-PEERS:
-      type: ipv4
-      password: AQQvKeimxJu+uGQ/yYvv9w==
-      maximum_routes: 12000
-      send_community: all
-    EVPN-OVERLAY-PEERS:
-      type: evpn
-      update_source: Loopback0
-      bfd: true
-      ebgp_multihop: '3'
-      password: q+VNViP5i4rVjW1cxFv2wA==
-      send_community: all
-      maximum_routes: 0
+  - name: MLAG-IPv4-UNDERLAY-PEER
+    type: ipv4
+    remote_as: '65101'
+    next_hop_self: true
+    description: leaf1
+    password: vnEaG8gMeQf3d3cN6PktXQ==
+    maximum_routes: 12000
+    send_community: all
+    route_map_in: RM-MLAG-PEER-IN
+  - name: IPv4-UNDERLAY-PEERS
+    type: ipv4
+    password: AQQvKeimxJu+uGQ/yYvv9w==
+    maximum_routes: 12000
+    send_community: all
+  - name: EVPN-OVERLAY-PEERS
+    type: evpn
+    update_source: Loopback0
+    bfd: true
+    password: q+VNViP5i4rVjW1cxFv2wA==
+    send_community: all
+    maximum_routes: 0
+    ebgp_multihop: 3
   address_family_ipv4:
     peer_groups:
-      MLAG-IPv4-UNDERLAY-PEER:
-        activate: true
-      IPv4-UNDERLAY-PEERS:
-        activate: true
-      EVPN-OVERLAY-PEERS:
-        activate: false
+    - name: MLAG-IPv4-UNDERLAY-PEER
+      activate: true
+    - name: IPv4-UNDERLAY-PEERS
+      activate: true
+    - name: EVPN-OVERLAY-PEERS
+      activate: false
   neighbors:
-    10.255.251.0:
-      peer_group: MLAG-IPv4-UNDERLAY-PEER
-      description: leaf1
-    172.30.255.4:
-      peer_group: IPv4-UNDERLAY-PEERS
-      remote_as: '65001'
-      description: spine1_Ethernet3
-    172.30.255.6:
-      peer_group: IPv4-UNDERLAY-PEERS
-      remote_as: '65001'
-      description: spine2_Ethernet3
-    192.0.255.1:
-      peer_group: EVPN-OVERLAY-PEERS
-      description: spine1
-      remote_as: '65001'
-    192.0.255.2:
-      peer_group: EVPN-OVERLAY-PEERS
-      description: spine2
-      remote_as: '65001'
+  - ip_address: 10.255.251.0
+    peer_group: MLAG-IPv4-UNDERLAY-PEER
+    description: leaf1
+  - ip_address: 172.30.255.4
+    peer_group: IPv4-UNDERLAY-PEERS
+    remote_as: '65001'
+    description: spine1_Ethernet3
+  - ip_address: 172.30.255.6
+    peer_group: IPv4-UNDERLAY-PEERS
+    remote_as: '65001'
+    description: spine2_Ethernet3
+  - ip_address: 192.0.255.1
+    peer_group: EVPN-OVERLAY-PEERS
+    description: spine1
+    remote_as: '65001'
+  - ip_address: 192.0.255.2
+    peer_group: EVPN-OVERLAY-PEERS
+    description: spine2
+    remote_as: '65001'
   redistribute_routes:
-    connected:
-      route_map: RM-CONN-2-BGP
+  - source_protocol: connected
+    route_map: RM-CONN-2-BGP
   address_family_evpn:
     peer_groups:
-      EVPN-OVERLAY-PEERS:
-        activate: true
+    - name: EVPN-OVERLAY-PEERS
+      activate: true
   vrfs:
-    Tenant_A_OP_Zone:
-      router_id: 192.0.255.4
-      rd: 192.0.255.4:10
-      route_targets:
-        import:
-          evpn:
-          - '10:10'
-        export:
-          evpn:
-          - '10:10'
-      neighbors:
-        10.255.251.0:
-          peer_group: MLAG-IPv4-UNDERLAY-PEER
-      redistribute_routes:
-      - connected
-  vlan_aware_bundles:
-    Tenant_A_OP_Zone:
-      rd: 192.0.255.4:10
-      route_targets:
-        both:
+  - name: Tenant_A_OP_Zone
+    router_id: 192.0.255.4
+    rd: 192.0.255.4:10
+    route_targets:
+      import:
+      - address_family: evpn
+        route_targets:
         - '10:10'
-      redistribute_routes:
-      - learned
-      vlan: 110
-    Tenant_A_VMOTION:
-      tenant: Tenant_A
-      rd: 192.0.255.4:55160
-      route_targets:
-        both:
-        - 55160:55160
-      redistribute_routes:
-      - learned
-      vlan: 160
+      export:
+      - address_family: evpn
+        route_targets:
+        - '10:10'
+    redistribute_routes:
+    - source_protocol: connected
+    neighbors:
+    - ip_address: 10.255.251.0
+      peer_group: MLAG-IPv4-UNDERLAY-PEER
+  vlan_aware_bundles:
+  - name: Tenant_A_OP_Zone
+    rd: 192.0.255.4:10
+    route_targets:
+      both:
+      - '10:10'
+    redistribute_routes:
+    - learned
+    vlan: '110'
+  - name: Tenant_A_VMOTION
+    tenant: Tenant_A
+    rd: 192.0.255.4:55160
+    route_targets:
+      both:
+      - 55160:55160
+    redistribute_routes:
+    - learned
+    vlan: '160'
 static_routes:
 - vrf: default
   destination_address_prefix: 0.0.0.0/0
@@ -110,208 +119,204 @@ vlan_internal_order:
   range:
     beginning: 1006
     ending: 1199
-name_server:
-  source:
-    vrf: default
-  nodes:
-  - 192.168.2.1
-  - 8.8.8.8
+ip_name_servers:
+- ip_address: 192.168.2.1
+  vrf: default
+- ip_address: 8.8.8.8
+  vrf: default
 spanning_tree:
   mode: mstp
   mst_instances:
-    '0':
-      priority: 16384
+  - id: '0'
+    priority: 16384
   no_spanning_tree_vlan: 4093-4094
 vrfs:
-  default:
-    ip_routing: false
-  Tenant_A_OP_Zone:
-    tenant: Tenant_A
-    ip_routing: true
+- name: default
+  ip_routing: false
+- name: Tenant_A_OP_Zone
+  tenant: Tenant_A
+  ip_routing: true
 management_interfaces:
-  Management1:
-    description: oob_management
-    shutdown: false
-    vrf: default
-    ip_address: 192.168.0.13/24
-    gateway: 192.168.0.1
-    type: oob
+- name: Management1
+  description: oob_management
+  shutdown: false
+  vrf: default
+  ip_address: 192.168.0.13/24
+  gateway: 192.168.0.1
+  type: oob
 management_api_http:
   enable_vrfs:
-    default: {}
+  - name: default
   enable_https: true
 vlans:
-  4093:
-    tenant: system
-    name: LEAF_PEER_L3
-    trunk_groups:
-    - LEAF_PEER_L3
-  4094:
-    tenant: system
-    name: MLAG_PEER
-    trunk_groups:
-    - MLAG
-  110:
-    tenant: Tenant_A
-    name: Tenant_A_OP_Zone_1
-  3009:
-    tenant: Tenant_A
-    name: MLAG_iBGP_Tenant_A_OP_Zone
-    trunk_groups:
-    - LEAF_PEER_L3
-  160:
-    tenant: Tenant_A
-    name: Tenant_A_VMOTION
+- id: 4093
+  tenant: system
+  name: LEAF_PEER_L3
+  trunk_groups:
+  - LEAF_PEER_L3
+- id: 4094
+  tenant: system
+  name: MLAG_PEER
+  trunk_groups:
+  - MLAG
+- id: 110
+  name: Tenant_A_OP_Zone_1
+  tenant: Tenant_A
+- id: 3009
+  name: MLAG_iBGP_Tenant_A_OP_Zone
+  trunk_groups:
+  - LEAF_PEER_L3
+  tenant: Tenant_A
+- id: 160
+  name: Tenant_A_VMOTION
+  tenant: Tenant_A
 vlan_interfaces:
-  Vlan4093:
-    description: MLAG_PEER_L3_PEERING
-    shutdown: false
-    mtu: 1500
-    ip_address: 10.255.251.1/31
-  Vlan4094:
-    description: MLAG_PEER
-    shutdown: false
-    ip_address: 10.255.252.1/31
-    no_autostate: true
-    mtu: 1500
-  Vlan110:
-    tenant: Tenant_A
-    tags:
-    - opzone
-    description: Tenant_A_OP_Zone_1
-    shutdown: false
-    vrf: Tenant_A_OP_Zone
-    ip_address_virtual: 10.1.10.1/24
-  Vlan3009:
-    tenant: Tenant_A
-    type: underlay_peering
-    shutdown: false
-    description: 'MLAG_PEER_L3_iBGP: vrf Tenant_A_OP_Zone'
-    vrf: Tenant_A_OP_Zone
-    ip_address: 10.255.251.1/31
-    mtu: 1500
+- name: Vlan4093
+  description: MLAG_PEER_L3_PEERING
+  shutdown: false
+  mtu: 1500
+  ip_address: 10.255.251.1/31
+- name: Vlan4094
+  description: MLAG_PEER
+  shutdown: false
+  ip_address: 10.255.252.1/31
+  no_autostate: true
+  mtu: 1500
+- name: Vlan110
+  tenant: Tenant_A
+  tags:
+  - opzone
+  description: Tenant_A_OP_Zone_1
+  shutdown: false
+  ip_address_virtual: 10.1.10.1/24
+  vrf: Tenant_A_OP_Zone
+- name: Vlan3009
+  tenant: Tenant_A
+  type: underlay_peering
+  shutdown: false
+  description: 'MLAG_PEER_L3_iBGP: vrf Tenant_A_OP_Zone'
+  vrf: Tenant_A_OP_Zone
+  mtu: 1500
+  ip_address: 10.255.251.1/31
 port_channel_interfaces:
-  Port-Channel1:
-    description: MLAG_PEER_leaf1_Po1
-    type: switched
-    shutdown: false
-    vlans: 2-4094
-    mode: trunk
-    trunk_groups:
-    - LEAF_PEER_L3
-    - MLAG
-  Port-Channel4:
-    description: host1_PortChannel
-    type: switched
-    shutdown: false
-    mode: access
-    vlans: 110
-    mlag: 4
+- name: Port-Channel1
+  description: MLAG_PEER_leaf1_Po1
+  type: switched
+  shutdown: false
+  mode: trunk
+  trunk_groups:
+  - LEAF_PEER_L3
+  - MLAG
+- name: Port-Channel4
+  description: host1_PortChannel
+  type: switched
+  shutdown: false
+  mode: access
+  vlans: '110'
+  mlag: 4
 ethernet_interfaces:
-  Ethernet1:
-    peer: leaf1
-    peer_interface: Ethernet1
-    peer_type: mlag_peer
-    description: MLAG_PEER_leaf1_Ethernet1
-    type: switched
-    shutdown: false
-    channel_group:
-      id: 1
-      mode: active
-  Ethernet6:
-    peer: leaf1
-    peer_interface: Ethernet6
-    peer_type: mlag_peer
-    description: MLAG_PEER_leaf1_Ethernet6
-    type: switched
-    shutdown: false
-    channel_group:
-      id: 1
-      mode: active
-  Ethernet2:
-    peer: spine1
-    peer_interface: Ethernet3
-    peer_type: spine
-    description: P2P_LINK_TO_SPINE1_Ethernet3
-    mtu: 1500
-    type: routed
-    shutdown: false
-    ip_address: 172.30.255.5/31
-  Ethernet3:
-    peer: spine2
-    peer_interface: Ethernet3
-    peer_type: spine
-    description: P2P_LINK_TO_SPINE2_Ethernet3
-    mtu: 1500
-    type: routed
-    shutdown: false
-    ip_address: 172.30.255.7/31
-  Ethernet4:
-    peer: host1
-    peer_interface: Eth3
-    peer_type: server
-    description: host1_Eth3
-    type: switched
-    shutdown: false
-    mode: access
-    vlans: 110
-    channel_group:
-      id: 4
-      mode: active
-  Ethernet5:
-    peer: host1
-    peer_interface: Eth4
-    peer_type: server
-    description: host1_Eth4
-    type: switched
-    shutdown: false
-    mode: access
-    vlans: 110
-    channel_group:
-      id: 4
-      mode: active
+- name: Ethernet1
+  peer: leaf1
+  peer_interface: Ethernet1
+  peer_type: mlag_peer
+  description: MLAG_PEER_leaf1_Ethernet1
+  type: port-channel-member
+  shutdown: false
+  channel_group:
+    id: 1
+    mode: active
+- name: Ethernet6
+  peer: leaf1
+  peer_interface: Ethernet6
+  peer_type: mlag_peer
+  description: MLAG_PEER_leaf1_Ethernet6
+  type: port-channel-member
+  shutdown: false
+  channel_group:
+    id: 1
+    mode: active
+- name: Ethernet2
+  peer: spine1
+  peer_interface: Ethernet3
+  peer_type: spine
+  description: P2P_LINK_TO_SPINE1_Ethernet3
+  shutdown: false
+  mtu: 1500
+  type: routed
+  ip_address: 172.30.255.5/31
+- name: Ethernet3
+  peer: spine2
+  peer_interface: Ethernet3
+  peer_type: spine
+  description: P2P_LINK_TO_SPINE2_Ethernet3
+  shutdown: false
+  mtu: 1500
+  type: routed
+  ip_address: 172.30.255.7/31
+- name: Ethernet4
+  peer: host1
+  peer_interface: Eth3
+  peer_type: server
+  port_profile: TENANT_A
+  description: host1_Eth3
+  shutdown: false
+  type: port-channel-member
+  channel_group:
+    id: 4
+    mode: active
+- name: Ethernet5
+  peer: host1
+  peer_interface: Eth4
+  peer_type: server
+  port_profile: TENANT_A
+  description: host1_Eth4
+  shutdown: false
+  type: port-channel-member
+  channel_group:
+    id: 4
+    mode: active
 mlag_configuration:
   domain_id: pod1
   local_interface: Vlan4094
   peer_address: 10.255.252.0
   peer_link: Port-Channel1
-  reload_delay_mlag: 300
-  reload_delay_non_mlag: 330
+  reload_delay_mlag: '300'
+  reload_delay_non_mlag: '330'
 route_maps:
-  RM-MLAG-PEER-IN:
-    sequence_numbers:
-      10:
-        type: permit
-        set:
-        - origin incomplete
-        description: Make routes learned over MLAG Peer-link less preferred on spines to ensure optimal routing
-  RM-CONN-2-BGP:
-    sequence_numbers:
-      10:
-        type: permit
-        match:
-        - ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY
+- name: RM-MLAG-PEER-IN
+  sequence_numbers:
+  - sequence: 10
+    type: permit
+    set:
+    - origin incomplete
+    description: Make routes learned over MLAG Peer-link less preferred on spines to ensure optimal routing
+- name: RM-CONN-2-BGP
+  sequence_numbers:
+  - sequence: 10
+    type: permit
+    match:
+    - ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY
 loopback_interfaces:
-  Loopback0:
-    description: EVPN_Overlay_Peering
-    shutdown: false
-    ip_address: 192.0.255.4/32
-  Loopback1:
-    description: VTEP_VXLAN_Tunnel_Source
-    shutdown: false
-    ip_address: 192.0.254.3/32
-  Loopback100:
-    description: Tenant_A_OP_Zone_VTEP_DIAGNOSTICS
-    shutdown: false
-    vrf: Tenant_A_OP_Zone
-    ip_address: 10.255.1.4/32
+- name: Loopback0
+  description: EVPN_Overlay_Peering
+  shutdown: false
+  ip_address: 192.0.255.4/32
+- name: Loopback1
+  description: VTEP_VXLAN_Tunnel_Source
+  shutdown: false
+  ip_address: 192.0.254.3/32
+- name: Loopback100
+  description: Tenant_A_OP_Zone_VTEP_DIAGNOSTICS
+  shutdown: false
+  vrf: Tenant_A_OP_Zone
+  ip_address: 10.255.1.4/32
 prefix_lists:
-  PL-LOOPBACKS-EVPN-OVERLAY:
-    sequence_numbers:
-      10:
-        action: permit 192.0.255.0/24 eq 32
-      20:
-        action: permit 192.0.254.0/24 eq 32
+- name: PL-LOOPBACKS-EVPN-OVERLAY
+  sequence_numbers:
+  - sequence: 10
+    action: permit 192.0.255.0/24 eq 32
+  - sequence: 20
+    action: permit 192.0.254.0/24 eq 32
 router_bfd:
   multihop:
     interval: 1200
@@ -324,17 +329,17 @@ vxlan_interface:
   Vxlan1:
     description: leaf2_VTEP
     vxlan:
+      udp_port: 4789
       source_interface: Loopback1
       virtual_router_encapsulation_mac_address: mlag-system-id
-      udp_port: 4789
       vlans:
-        110:
-          vni: 10110
-        160:
-          vni: 55160
+      - id: 110
+        vni: 10110
+      - id: 160
+        vni: 55160
       vrfs:
-        Tenant_A_OP_Zone:
-          vni: 10
+      - name: Tenant_A_OP_Zone
+        vni: 10
 virtual_source_nat_vrfs:
-  Tenant_A_OP_Zone:
-    ip_address: 10.255.1.4
+- name: Tenant_A_OP_Zone
+  ip_address: 10.255.1.4

--- a/atd-inventory/intended/structured_configs/leaf3.yml
+++ b/atd-inventory/intended/structured_configs/leaf3.yml
@@ -1,104 +1,113 @@
 router_bgp:
   as: '65102'
   router_id: 192.0.255.5
-  bgp_defaults:
-  - no bgp default ipv4-unicast
-  - distance bgp 20 200 200
-  - graceful-restart restart-time 300
-  - graceful-restart
-  - maximum-paths 4 ecmp 4
+  distance:
+    external_routes: 20
+    internal_routes: 200
+    local_routes: 200
+  bgp:
+    default:
+      ipv4_unicast: false
+  maximum_paths:
+    paths: 4
+    ecmp: 4
+  graceful_restart:
+    enabled: true
+    restart_time: 300
   peer_groups:
-    MLAG-IPv4-UNDERLAY-PEER:
-      type: ipv4
-      remote_as: '65102'
-      next_hop_self: true
-      description: leaf4
-      password: vnEaG8gMeQf3d3cN6PktXQ==
-      maximum_routes: 12000
-      send_community: all
-      route_map_in: RM-MLAG-PEER-IN
-    IPv4-UNDERLAY-PEERS:
-      type: ipv4
-      password: AQQvKeimxJu+uGQ/yYvv9w==
-      maximum_routes: 12000
-      send_community: all
-    EVPN-OVERLAY-PEERS:
-      type: evpn
-      update_source: Loopback0
-      bfd: true
-      ebgp_multihop: '3'
-      password: q+VNViP5i4rVjW1cxFv2wA==
-      send_community: all
-      maximum_routes: 0
+  - name: MLAG-IPv4-UNDERLAY-PEER
+    type: ipv4
+    remote_as: '65102'
+    next_hop_self: true
+    description: leaf4
+    password: vnEaG8gMeQf3d3cN6PktXQ==
+    maximum_routes: 12000
+    send_community: all
+    route_map_in: RM-MLAG-PEER-IN
+  - name: IPv4-UNDERLAY-PEERS
+    type: ipv4
+    password: AQQvKeimxJu+uGQ/yYvv9w==
+    maximum_routes: 12000
+    send_community: all
+  - name: EVPN-OVERLAY-PEERS
+    type: evpn
+    update_source: Loopback0
+    bfd: true
+    password: q+VNViP5i4rVjW1cxFv2wA==
+    send_community: all
+    maximum_routes: 0
+    ebgp_multihop: 3
   address_family_ipv4:
     peer_groups:
-      MLAG-IPv4-UNDERLAY-PEER:
-        activate: true
-      IPv4-UNDERLAY-PEERS:
-        activate: true
-      EVPN-OVERLAY-PEERS:
-        activate: false
+    - name: MLAG-IPv4-UNDERLAY-PEER
+      activate: true
+    - name: IPv4-UNDERLAY-PEERS
+      activate: true
+    - name: EVPN-OVERLAY-PEERS
+      activate: false
   neighbors:
-    10.255.251.5:
-      peer_group: MLAG-IPv4-UNDERLAY-PEER
-      description: leaf4
-    172.30.255.8:
-      peer_group: IPv4-UNDERLAY-PEERS
-      remote_as: '65001'
-      description: spine1_Ethernet4
-    172.30.255.10:
-      peer_group: IPv4-UNDERLAY-PEERS
-      remote_as: '65001'
-      description: spine2_Ethernet4
-    192.0.255.1:
-      peer_group: EVPN-OVERLAY-PEERS
-      description: spine1
-      remote_as: '65001'
-    192.0.255.2:
-      peer_group: EVPN-OVERLAY-PEERS
-      description: spine2
-      remote_as: '65001'
+  - ip_address: 10.255.251.5
+    peer_group: MLAG-IPv4-UNDERLAY-PEER
+    description: leaf4
+  - ip_address: 172.30.255.8
+    peer_group: IPv4-UNDERLAY-PEERS
+    remote_as: '65001'
+    description: spine1_Ethernet4
+  - ip_address: 172.30.255.10
+    peer_group: IPv4-UNDERLAY-PEERS
+    remote_as: '65001'
+    description: spine2_Ethernet4
+  - ip_address: 192.0.255.1
+    peer_group: EVPN-OVERLAY-PEERS
+    description: spine1
+    remote_as: '65001'
+  - ip_address: 192.0.255.2
+    peer_group: EVPN-OVERLAY-PEERS
+    description: spine2
+    remote_as: '65001'
   redistribute_routes:
-    connected:
-      route_map: RM-CONN-2-BGP
+  - source_protocol: connected
+    route_map: RM-CONN-2-BGP
   address_family_evpn:
     peer_groups:
-      EVPN-OVERLAY-PEERS:
-        activate: true
+    - name: EVPN-OVERLAY-PEERS
+      activate: true
   vrfs:
-    Tenant_A_OP_Zone:
-      router_id: 192.0.255.5
-      rd: 192.0.255.5:10
-      route_targets:
-        import:
-          evpn:
-          - '10:10'
-        export:
-          evpn:
-          - '10:10'
-      neighbors:
-        10.255.251.5:
-          peer_group: MLAG-IPv4-UNDERLAY-PEER
-      redistribute_routes:
-      - connected
-  vlan_aware_bundles:
-    Tenant_A_OP_Zone:
-      rd: 192.0.255.5:10
-      route_targets:
-        both:
+  - name: Tenant_A_OP_Zone
+    router_id: 192.0.255.5
+    rd: 192.0.255.5:10
+    route_targets:
+      import:
+      - address_family: evpn
+        route_targets:
         - '10:10'
-      redistribute_routes:
-      - learned
-      vlan: 110
-    Tenant_A_VMOTION:
-      tenant: Tenant_A
-      rd: 192.0.255.5:55160
-      route_targets:
-        both:
-        - 55160:55160
-      redistribute_routes:
-      - learned
-      vlan: 160
+      export:
+      - address_family: evpn
+        route_targets:
+        - '10:10'
+    redistribute_routes:
+    - source_protocol: connected
+    neighbors:
+    - ip_address: 10.255.251.5
+      peer_group: MLAG-IPv4-UNDERLAY-PEER
+  vlan_aware_bundles:
+  - name: Tenant_A_OP_Zone
+    rd: 192.0.255.5:10
+    route_targets:
+      both:
+      - '10:10'
+    redistribute_routes:
+    - learned
+    vlan: '110'
+  - name: Tenant_A_VMOTION
+    tenant: Tenant_A
+    rd: 192.0.255.5:55160
+    route_targets:
+      both:
+      - 55160:55160
+    redistribute_routes:
+    - learned
+    vlan: '160'
 static_routes:
 - vrf: default
   destination_address_prefix: 0.0.0.0/0
@@ -110,208 +119,204 @@ vlan_internal_order:
   range:
     beginning: 1006
     ending: 1199
-name_server:
-  source:
-    vrf: default
-  nodes:
-  - 192.168.2.1
-  - 8.8.8.8
+ip_name_servers:
+- ip_address: 192.168.2.1
+  vrf: default
+- ip_address: 8.8.8.8
+  vrf: default
 spanning_tree:
   mode: mstp
   mst_instances:
-    '0':
-      priority: 16384
+  - id: '0'
+    priority: 16384
   no_spanning_tree_vlan: 4093-4094
 vrfs:
-  default:
-    ip_routing: false
-  Tenant_A_OP_Zone:
-    tenant: Tenant_A
-    ip_routing: true
+- name: default
+  ip_routing: false
+- name: Tenant_A_OP_Zone
+  tenant: Tenant_A
+  ip_routing: true
 management_interfaces:
-  Management1:
-    description: oob_management
-    shutdown: false
-    vrf: default
-    ip_address: 192.168.0.14/24
-    gateway: 192.168.0.1
-    type: oob
+- name: Management1
+  description: oob_management
+  shutdown: false
+  vrf: default
+  ip_address: 192.168.0.14/24
+  gateway: 192.168.0.1
+  type: oob
 management_api_http:
   enable_vrfs:
-    default: {}
+  - name: default
   enable_https: true
 vlans:
-  4093:
-    tenant: system
-    name: LEAF_PEER_L3
-    trunk_groups:
-    - LEAF_PEER_L3
-  4094:
-    tenant: system
-    name: MLAG_PEER
-    trunk_groups:
-    - MLAG
-  110:
-    tenant: Tenant_A
-    name: Tenant_A_OP_Zone_1
-  3009:
-    tenant: Tenant_A
-    name: MLAG_iBGP_Tenant_A_OP_Zone
-    trunk_groups:
-    - LEAF_PEER_L3
-  160:
-    tenant: Tenant_A
-    name: Tenant_A_VMOTION
+- id: 4093
+  tenant: system
+  name: LEAF_PEER_L3
+  trunk_groups:
+  - LEAF_PEER_L3
+- id: 4094
+  tenant: system
+  name: MLAG_PEER
+  trunk_groups:
+  - MLAG
+- id: 110
+  name: Tenant_A_OP_Zone_1
+  tenant: Tenant_A
+- id: 3009
+  name: MLAG_iBGP_Tenant_A_OP_Zone
+  trunk_groups:
+  - LEAF_PEER_L3
+  tenant: Tenant_A
+- id: 160
+  name: Tenant_A_VMOTION
+  tenant: Tenant_A
 vlan_interfaces:
-  Vlan4093:
-    description: MLAG_PEER_L3_PEERING
-    shutdown: false
-    mtu: 1500
-    ip_address: 10.255.251.4/31
-  Vlan4094:
-    description: MLAG_PEER
-    shutdown: false
-    ip_address: 10.255.252.4/31
-    no_autostate: true
-    mtu: 1500
-  Vlan110:
-    tenant: Tenant_A
-    tags:
-    - opzone
-    description: Tenant_A_OP_Zone_1
-    shutdown: false
-    vrf: Tenant_A_OP_Zone
-    ip_address_virtual: 10.1.10.1/24
-  Vlan3009:
-    tenant: Tenant_A
-    type: underlay_peering
-    shutdown: false
-    description: 'MLAG_PEER_L3_iBGP: vrf Tenant_A_OP_Zone'
-    vrf: Tenant_A_OP_Zone
-    ip_address: 10.255.251.4/31
-    mtu: 1500
+- name: Vlan4093
+  description: MLAG_PEER_L3_PEERING
+  shutdown: false
+  mtu: 1500
+  ip_address: 10.255.251.4/31
+- name: Vlan4094
+  description: MLAG_PEER
+  shutdown: false
+  ip_address: 10.255.252.4/31
+  no_autostate: true
+  mtu: 1500
+- name: Vlan110
+  tenant: Tenant_A
+  tags:
+  - opzone
+  description: Tenant_A_OP_Zone_1
+  shutdown: false
+  ip_address_virtual: 10.1.10.1/24
+  vrf: Tenant_A_OP_Zone
+- name: Vlan3009
+  tenant: Tenant_A
+  type: underlay_peering
+  shutdown: false
+  description: 'MLAG_PEER_L3_iBGP: vrf Tenant_A_OP_Zone'
+  vrf: Tenant_A_OP_Zone
+  mtu: 1500
+  ip_address: 10.255.251.4/31
 port_channel_interfaces:
-  Port-Channel1:
-    description: MLAG_PEER_leaf4_Po1
-    type: switched
-    shutdown: false
-    vlans: 2-4094
-    mode: trunk
-    trunk_groups:
-    - LEAF_PEER_L3
-    - MLAG
-  Port-Channel4:
-    description: host2_PortChannel
-    type: switched
-    shutdown: false
-    mode: access
-    vlans: 110
-    mlag: 4
+- name: Port-Channel1
+  description: MLAG_PEER_leaf4_Po1
+  type: switched
+  shutdown: false
+  mode: trunk
+  trunk_groups:
+  - LEAF_PEER_L3
+  - MLAG
+- name: Port-Channel4
+  description: host2_PortChannel
+  type: switched
+  shutdown: false
+  mode: access
+  vlans: '110'
+  mlag: 4
 ethernet_interfaces:
-  Ethernet1:
-    peer: leaf4
-    peer_interface: Ethernet1
-    peer_type: mlag_peer
-    description: MLAG_PEER_leaf4_Ethernet1
-    type: switched
-    shutdown: false
-    channel_group:
-      id: 1
-      mode: active
-  Ethernet6:
-    peer: leaf4
-    peer_interface: Ethernet6
-    peer_type: mlag_peer
-    description: MLAG_PEER_leaf4_Ethernet6
-    type: switched
-    shutdown: false
-    channel_group:
-      id: 1
-      mode: active
-  Ethernet2:
-    peer: spine1
-    peer_interface: Ethernet4
-    peer_type: spine
-    description: P2P_LINK_TO_SPINE1_Ethernet4
-    mtu: 1500
-    type: routed
-    shutdown: false
-    ip_address: 172.30.255.9/31
-  Ethernet3:
-    peer: spine2
-    peer_interface: Ethernet4
-    peer_type: spine
-    description: P2P_LINK_TO_SPINE2_Ethernet4
-    mtu: 1500
-    type: routed
-    shutdown: false
-    ip_address: 172.30.255.11/31
-  Ethernet4:
-    peer: host2
-    peer_interface: Eth1
-    peer_type: server
-    description: host2_Eth1
-    type: switched
-    shutdown: false
-    mode: access
-    vlans: 110
-    channel_group:
-      id: 4
-      mode: active
-  Ethernet5:
-    peer: host2
-    peer_interface: Eth2
-    peer_type: server
-    description: host2_Eth2
-    type: switched
-    shutdown: false
-    mode: access
-    vlans: 110
-    channel_group:
-      id: 4
-      mode: active
+- name: Ethernet1
+  peer: leaf4
+  peer_interface: Ethernet1
+  peer_type: mlag_peer
+  description: MLAG_PEER_leaf4_Ethernet1
+  type: port-channel-member
+  shutdown: false
+  channel_group:
+    id: 1
+    mode: active
+- name: Ethernet6
+  peer: leaf4
+  peer_interface: Ethernet6
+  peer_type: mlag_peer
+  description: MLAG_PEER_leaf4_Ethernet6
+  type: port-channel-member
+  shutdown: false
+  channel_group:
+    id: 1
+    mode: active
+- name: Ethernet2
+  peer: spine1
+  peer_interface: Ethernet4
+  peer_type: spine
+  description: P2P_LINK_TO_SPINE1_Ethernet4
+  shutdown: false
+  mtu: 1500
+  type: routed
+  ip_address: 172.30.255.9/31
+- name: Ethernet3
+  peer: spine2
+  peer_interface: Ethernet4
+  peer_type: spine
+  description: P2P_LINK_TO_SPINE2_Ethernet4
+  shutdown: false
+  mtu: 1500
+  type: routed
+  ip_address: 172.30.255.11/31
+- name: Ethernet4
+  peer: host2
+  peer_interface: Eth1
+  peer_type: server
+  port_profile: TENANT_A
+  description: host2_Eth1
+  shutdown: false
+  type: port-channel-member
+  channel_group:
+    id: 4
+    mode: active
+- name: Ethernet5
+  peer: host2
+  peer_interface: Eth2
+  peer_type: server
+  port_profile: TENANT_A
+  description: host2_Eth2
+  shutdown: false
+  type: port-channel-member
+  channel_group:
+    id: 4
+    mode: active
 mlag_configuration:
   domain_id: pod2
   local_interface: Vlan4094
   peer_address: 10.255.252.5
   peer_link: Port-Channel1
-  reload_delay_mlag: 300
-  reload_delay_non_mlag: 330
+  reload_delay_mlag: '300'
+  reload_delay_non_mlag: '330'
 route_maps:
-  RM-MLAG-PEER-IN:
-    sequence_numbers:
-      10:
-        type: permit
-        set:
-        - origin incomplete
-        description: Make routes learned over MLAG Peer-link less preferred on spines to ensure optimal routing
-  RM-CONN-2-BGP:
-    sequence_numbers:
-      10:
-        type: permit
-        match:
-        - ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY
+- name: RM-MLAG-PEER-IN
+  sequence_numbers:
+  - sequence: 10
+    type: permit
+    set:
+    - origin incomplete
+    description: Make routes learned over MLAG Peer-link less preferred on spines to ensure optimal routing
+- name: RM-CONN-2-BGP
+  sequence_numbers:
+  - sequence: 10
+    type: permit
+    match:
+    - ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY
 loopback_interfaces:
-  Loopback0:
-    description: EVPN_Overlay_Peering
-    shutdown: false
-    ip_address: 192.0.255.5/32
-  Loopback1:
-    description: VTEP_VXLAN_Tunnel_Source
-    shutdown: false
-    ip_address: 192.0.254.5/32
-  Loopback100:
-    description: Tenant_A_OP_Zone_VTEP_DIAGNOSTICS
-    shutdown: false
-    vrf: Tenant_A_OP_Zone
-    ip_address: 10.255.1.5/32
+- name: Loopback0
+  description: EVPN_Overlay_Peering
+  shutdown: false
+  ip_address: 192.0.255.5/32
+- name: Loopback1
+  description: VTEP_VXLAN_Tunnel_Source
+  shutdown: false
+  ip_address: 192.0.254.5/32
+- name: Loopback100
+  description: Tenant_A_OP_Zone_VTEP_DIAGNOSTICS
+  shutdown: false
+  vrf: Tenant_A_OP_Zone
+  ip_address: 10.255.1.5/32
 prefix_lists:
-  PL-LOOPBACKS-EVPN-OVERLAY:
-    sequence_numbers:
-      10:
-        action: permit 192.0.255.0/24 eq 32
-      20:
-        action: permit 192.0.254.0/24 eq 32
+- name: PL-LOOPBACKS-EVPN-OVERLAY
+  sequence_numbers:
+  - sequence: 10
+    action: permit 192.0.255.0/24 eq 32
+  - sequence: 20
+    action: permit 192.0.254.0/24 eq 32
 router_bfd:
   multihop:
     interval: 1200
@@ -324,17 +329,17 @@ vxlan_interface:
   Vxlan1:
     description: leaf3_VTEP
     vxlan:
+      udp_port: 4789
       source_interface: Loopback1
       virtual_router_encapsulation_mac_address: mlag-system-id
-      udp_port: 4789
       vlans:
-        110:
-          vni: 10110
-        160:
-          vni: 55160
+      - id: 110
+        vni: 10110
+      - id: 160
+        vni: 55160
       vrfs:
-        Tenant_A_OP_Zone:
-          vni: 10
+      - name: Tenant_A_OP_Zone
+        vni: 10
 virtual_source_nat_vrfs:
-  Tenant_A_OP_Zone:
-    ip_address: 10.255.1.5
+- name: Tenant_A_OP_Zone
+  ip_address: 10.255.1.5

--- a/atd-inventory/intended/structured_configs/leaf4.yml
+++ b/atd-inventory/intended/structured_configs/leaf4.yml
@@ -1,104 +1,113 @@
 router_bgp:
   as: '65102'
   router_id: 192.0.255.6
-  bgp_defaults:
-  - no bgp default ipv4-unicast
-  - distance bgp 20 200 200
-  - graceful-restart restart-time 300
-  - graceful-restart
-  - maximum-paths 4 ecmp 4
+  distance:
+    external_routes: 20
+    internal_routes: 200
+    local_routes: 200
+  bgp:
+    default:
+      ipv4_unicast: false
+  maximum_paths:
+    paths: 4
+    ecmp: 4
+  graceful_restart:
+    enabled: true
+    restart_time: 300
   peer_groups:
-    MLAG-IPv4-UNDERLAY-PEER:
-      type: ipv4
-      remote_as: '65102'
-      next_hop_self: true
-      description: leaf3
-      password: vnEaG8gMeQf3d3cN6PktXQ==
-      maximum_routes: 12000
-      send_community: all
-      route_map_in: RM-MLAG-PEER-IN
-    IPv4-UNDERLAY-PEERS:
-      type: ipv4
-      password: AQQvKeimxJu+uGQ/yYvv9w==
-      maximum_routes: 12000
-      send_community: all
-    EVPN-OVERLAY-PEERS:
-      type: evpn
-      update_source: Loopback0
-      bfd: true
-      ebgp_multihop: '3'
-      password: q+VNViP5i4rVjW1cxFv2wA==
-      send_community: all
-      maximum_routes: 0
+  - name: MLAG-IPv4-UNDERLAY-PEER
+    type: ipv4
+    remote_as: '65102'
+    next_hop_self: true
+    description: leaf3
+    password: vnEaG8gMeQf3d3cN6PktXQ==
+    maximum_routes: 12000
+    send_community: all
+    route_map_in: RM-MLAG-PEER-IN
+  - name: IPv4-UNDERLAY-PEERS
+    type: ipv4
+    password: AQQvKeimxJu+uGQ/yYvv9w==
+    maximum_routes: 12000
+    send_community: all
+  - name: EVPN-OVERLAY-PEERS
+    type: evpn
+    update_source: Loopback0
+    bfd: true
+    password: q+VNViP5i4rVjW1cxFv2wA==
+    send_community: all
+    maximum_routes: 0
+    ebgp_multihop: 3
   address_family_ipv4:
     peer_groups:
-      MLAG-IPv4-UNDERLAY-PEER:
-        activate: true
-      IPv4-UNDERLAY-PEERS:
-        activate: true
-      EVPN-OVERLAY-PEERS:
-        activate: false
+    - name: MLAG-IPv4-UNDERLAY-PEER
+      activate: true
+    - name: IPv4-UNDERLAY-PEERS
+      activate: true
+    - name: EVPN-OVERLAY-PEERS
+      activate: false
   neighbors:
-    10.255.251.4:
-      peer_group: MLAG-IPv4-UNDERLAY-PEER
-      description: leaf3
-    172.30.255.12:
-      peer_group: IPv4-UNDERLAY-PEERS
-      remote_as: '65001'
-      description: spine1_Ethernet5
-    172.30.255.14:
-      peer_group: IPv4-UNDERLAY-PEERS
-      remote_as: '65001'
-      description: spine2_Ethernet5
-    192.0.255.1:
-      peer_group: EVPN-OVERLAY-PEERS
-      description: spine1
-      remote_as: '65001'
-    192.0.255.2:
-      peer_group: EVPN-OVERLAY-PEERS
-      description: spine2
-      remote_as: '65001'
+  - ip_address: 10.255.251.4
+    peer_group: MLAG-IPv4-UNDERLAY-PEER
+    description: leaf3
+  - ip_address: 172.30.255.12
+    peer_group: IPv4-UNDERLAY-PEERS
+    remote_as: '65001'
+    description: spine1_Ethernet5
+  - ip_address: 172.30.255.14
+    peer_group: IPv4-UNDERLAY-PEERS
+    remote_as: '65001'
+    description: spine2_Ethernet5
+  - ip_address: 192.0.255.1
+    peer_group: EVPN-OVERLAY-PEERS
+    description: spine1
+    remote_as: '65001'
+  - ip_address: 192.0.255.2
+    peer_group: EVPN-OVERLAY-PEERS
+    description: spine2
+    remote_as: '65001'
   redistribute_routes:
-    connected:
-      route_map: RM-CONN-2-BGP
+  - source_protocol: connected
+    route_map: RM-CONN-2-BGP
   address_family_evpn:
     peer_groups:
-      EVPN-OVERLAY-PEERS:
-        activate: true
+    - name: EVPN-OVERLAY-PEERS
+      activate: true
   vrfs:
-    Tenant_A_OP_Zone:
-      router_id: 192.0.255.6
-      rd: 192.0.255.6:10
-      route_targets:
-        import:
-          evpn:
-          - '10:10'
-        export:
-          evpn:
-          - '10:10'
-      neighbors:
-        10.255.251.4:
-          peer_group: MLAG-IPv4-UNDERLAY-PEER
-      redistribute_routes:
-      - connected
-  vlan_aware_bundles:
-    Tenant_A_OP_Zone:
-      rd: 192.0.255.6:10
-      route_targets:
-        both:
+  - name: Tenant_A_OP_Zone
+    router_id: 192.0.255.6
+    rd: 192.0.255.6:10
+    route_targets:
+      import:
+      - address_family: evpn
+        route_targets:
         - '10:10'
-      redistribute_routes:
-      - learned
-      vlan: 110
-    Tenant_A_VMOTION:
-      tenant: Tenant_A
-      rd: 192.0.255.6:55160
-      route_targets:
-        both:
-        - 55160:55160
-      redistribute_routes:
-      - learned
-      vlan: 160
+      export:
+      - address_family: evpn
+        route_targets:
+        - '10:10'
+    redistribute_routes:
+    - source_protocol: connected
+    neighbors:
+    - ip_address: 10.255.251.4
+      peer_group: MLAG-IPv4-UNDERLAY-PEER
+  vlan_aware_bundles:
+  - name: Tenant_A_OP_Zone
+    rd: 192.0.255.6:10
+    route_targets:
+      both:
+      - '10:10'
+    redistribute_routes:
+    - learned
+    vlan: '110'
+  - name: Tenant_A_VMOTION
+    tenant: Tenant_A
+    rd: 192.0.255.6:55160
+    route_targets:
+      both:
+      - 55160:55160
+    redistribute_routes:
+    - learned
+    vlan: '160'
 static_routes:
 - vrf: default
   destination_address_prefix: 0.0.0.0/0
@@ -110,208 +119,204 @@ vlan_internal_order:
   range:
     beginning: 1006
     ending: 1199
-name_server:
-  source:
-    vrf: default
-  nodes:
-  - 192.168.2.1
-  - 8.8.8.8
+ip_name_servers:
+- ip_address: 192.168.2.1
+  vrf: default
+- ip_address: 8.8.8.8
+  vrf: default
 spanning_tree:
   mode: mstp
   mst_instances:
-    '0':
-      priority: 16384
+  - id: '0'
+    priority: 16384
   no_spanning_tree_vlan: 4093-4094
 vrfs:
-  default:
-    ip_routing: false
-  Tenant_A_OP_Zone:
-    tenant: Tenant_A
-    ip_routing: true
+- name: default
+  ip_routing: false
+- name: Tenant_A_OP_Zone
+  tenant: Tenant_A
+  ip_routing: true
 management_interfaces:
-  Management1:
-    description: oob_management
-    shutdown: false
-    vrf: default
-    ip_address: 192.168.0.15/24
-    gateway: 192.168.0.1
-    type: oob
+- name: Management1
+  description: oob_management
+  shutdown: false
+  vrf: default
+  ip_address: 192.168.0.15/24
+  gateway: 192.168.0.1
+  type: oob
 management_api_http:
   enable_vrfs:
-    default: {}
+  - name: default
   enable_https: true
 vlans:
-  4093:
-    tenant: system
-    name: LEAF_PEER_L3
-    trunk_groups:
-    - LEAF_PEER_L3
-  4094:
-    tenant: system
-    name: MLAG_PEER
-    trunk_groups:
-    - MLAG
-  110:
-    tenant: Tenant_A
-    name: Tenant_A_OP_Zone_1
-  3009:
-    tenant: Tenant_A
-    name: MLAG_iBGP_Tenant_A_OP_Zone
-    trunk_groups:
-    - LEAF_PEER_L3
-  160:
-    tenant: Tenant_A
-    name: Tenant_A_VMOTION
+- id: 4093
+  tenant: system
+  name: LEAF_PEER_L3
+  trunk_groups:
+  - LEAF_PEER_L3
+- id: 4094
+  tenant: system
+  name: MLAG_PEER
+  trunk_groups:
+  - MLAG
+- id: 110
+  name: Tenant_A_OP_Zone_1
+  tenant: Tenant_A
+- id: 3009
+  name: MLAG_iBGP_Tenant_A_OP_Zone
+  trunk_groups:
+  - LEAF_PEER_L3
+  tenant: Tenant_A
+- id: 160
+  name: Tenant_A_VMOTION
+  tenant: Tenant_A
 vlan_interfaces:
-  Vlan4093:
-    description: MLAG_PEER_L3_PEERING
-    shutdown: false
-    mtu: 1500
-    ip_address: 10.255.251.5/31
-  Vlan4094:
-    description: MLAG_PEER
-    shutdown: false
-    ip_address: 10.255.252.5/31
-    no_autostate: true
-    mtu: 1500
-  Vlan110:
-    tenant: Tenant_A
-    tags:
-    - opzone
-    description: Tenant_A_OP_Zone_1
-    shutdown: false
-    vrf: Tenant_A_OP_Zone
-    ip_address_virtual: 10.1.10.1/24
-  Vlan3009:
-    tenant: Tenant_A
-    type: underlay_peering
-    shutdown: false
-    description: 'MLAG_PEER_L3_iBGP: vrf Tenant_A_OP_Zone'
-    vrf: Tenant_A_OP_Zone
-    ip_address: 10.255.251.5/31
-    mtu: 1500
+- name: Vlan4093
+  description: MLAG_PEER_L3_PEERING
+  shutdown: false
+  mtu: 1500
+  ip_address: 10.255.251.5/31
+- name: Vlan4094
+  description: MLAG_PEER
+  shutdown: false
+  ip_address: 10.255.252.5/31
+  no_autostate: true
+  mtu: 1500
+- name: Vlan110
+  tenant: Tenant_A
+  tags:
+  - opzone
+  description: Tenant_A_OP_Zone_1
+  shutdown: false
+  ip_address_virtual: 10.1.10.1/24
+  vrf: Tenant_A_OP_Zone
+- name: Vlan3009
+  tenant: Tenant_A
+  type: underlay_peering
+  shutdown: false
+  description: 'MLAG_PEER_L3_iBGP: vrf Tenant_A_OP_Zone'
+  vrf: Tenant_A_OP_Zone
+  mtu: 1500
+  ip_address: 10.255.251.5/31
 port_channel_interfaces:
-  Port-Channel1:
-    description: MLAG_PEER_leaf3_Po1
-    type: switched
-    shutdown: false
-    vlans: 2-4094
-    mode: trunk
-    trunk_groups:
-    - LEAF_PEER_L3
-    - MLAG
-  Port-Channel4:
-    description: host2_PortChannel
-    type: switched
-    shutdown: false
-    mode: access
-    vlans: 110
-    mlag: 4
+- name: Port-Channel1
+  description: MLAG_PEER_leaf3_Po1
+  type: switched
+  shutdown: false
+  mode: trunk
+  trunk_groups:
+  - LEAF_PEER_L3
+  - MLAG
+- name: Port-Channel4
+  description: host2_PortChannel
+  type: switched
+  shutdown: false
+  mode: access
+  vlans: '110'
+  mlag: 4
 ethernet_interfaces:
-  Ethernet1:
-    peer: leaf3
-    peer_interface: Ethernet1
-    peer_type: mlag_peer
-    description: MLAG_PEER_leaf3_Ethernet1
-    type: switched
-    shutdown: false
-    channel_group:
-      id: 1
-      mode: active
-  Ethernet6:
-    peer: leaf3
-    peer_interface: Ethernet6
-    peer_type: mlag_peer
-    description: MLAG_PEER_leaf3_Ethernet6
-    type: switched
-    shutdown: false
-    channel_group:
-      id: 1
-      mode: active
-  Ethernet2:
-    peer: spine1
-    peer_interface: Ethernet5
-    peer_type: spine
-    description: P2P_LINK_TO_SPINE1_Ethernet5
-    mtu: 1500
-    type: routed
-    shutdown: false
-    ip_address: 172.30.255.13/31
-  Ethernet3:
-    peer: spine2
-    peer_interface: Ethernet5
-    peer_type: spine
-    description: P2P_LINK_TO_SPINE2_Ethernet5
-    mtu: 1500
-    type: routed
-    shutdown: false
-    ip_address: 172.30.255.15/31
-  Ethernet4:
-    peer: host2
-    peer_interface: Eth3
-    peer_type: server
-    description: host2_Eth3
-    type: switched
-    shutdown: false
-    mode: access
-    vlans: 110
-    channel_group:
-      id: 4
-      mode: active
-  Ethernet5:
-    peer: host2
-    peer_interface: Eth4
-    peer_type: server
-    description: host2_Eth4
-    type: switched
-    shutdown: false
-    mode: access
-    vlans: 110
-    channel_group:
-      id: 4
-      mode: active
+- name: Ethernet1
+  peer: leaf3
+  peer_interface: Ethernet1
+  peer_type: mlag_peer
+  description: MLAG_PEER_leaf3_Ethernet1
+  type: port-channel-member
+  shutdown: false
+  channel_group:
+    id: 1
+    mode: active
+- name: Ethernet6
+  peer: leaf3
+  peer_interface: Ethernet6
+  peer_type: mlag_peer
+  description: MLAG_PEER_leaf3_Ethernet6
+  type: port-channel-member
+  shutdown: false
+  channel_group:
+    id: 1
+    mode: active
+- name: Ethernet2
+  peer: spine1
+  peer_interface: Ethernet5
+  peer_type: spine
+  description: P2P_LINK_TO_SPINE1_Ethernet5
+  shutdown: false
+  mtu: 1500
+  type: routed
+  ip_address: 172.30.255.13/31
+- name: Ethernet3
+  peer: spine2
+  peer_interface: Ethernet5
+  peer_type: spine
+  description: P2P_LINK_TO_SPINE2_Ethernet5
+  shutdown: false
+  mtu: 1500
+  type: routed
+  ip_address: 172.30.255.15/31
+- name: Ethernet4
+  peer: host2
+  peer_interface: Eth3
+  peer_type: server
+  port_profile: TENANT_A
+  description: host2_Eth3
+  shutdown: false
+  type: port-channel-member
+  channel_group:
+    id: 4
+    mode: active
+- name: Ethernet5
+  peer: host2
+  peer_interface: Eth4
+  peer_type: server
+  port_profile: TENANT_A
+  description: host2_Eth4
+  shutdown: false
+  type: port-channel-member
+  channel_group:
+    id: 4
+    mode: active
 mlag_configuration:
   domain_id: pod2
   local_interface: Vlan4094
   peer_address: 10.255.252.4
   peer_link: Port-Channel1
-  reload_delay_mlag: 300
-  reload_delay_non_mlag: 330
+  reload_delay_mlag: '300'
+  reload_delay_non_mlag: '330'
 route_maps:
-  RM-MLAG-PEER-IN:
-    sequence_numbers:
-      10:
-        type: permit
-        set:
-        - origin incomplete
-        description: Make routes learned over MLAG Peer-link less preferred on spines to ensure optimal routing
-  RM-CONN-2-BGP:
-    sequence_numbers:
-      10:
-        type: permit
-        match:
-        - ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY
+- name: RM-MLAG-PEER-IN
+  sequence_numbers:
+  - sequence: 10
+    type: permit
+    set:
+    - origin incomplete
+    description: Make routes learned over MLAG Peer-link less preferred on spines to ensure optimal routing
+- name: RM-CONN-2-BGP
+  sequence_numbers:
+  - sequence: 10
+    type: permit
+    match:
+    - ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY
 loopback_interfaces:
-  Loopback0:
-    description: EVPN_Overlay_Peering
-    shutdown: false
-    ip_address: 192.0.255.6/32
-  Loopback1:
-    description: VTEP_VXLAN_Tunnel_Source
-    shutdown: false
-    ip_address: 192.0.254.5/32
-  Loopback100:
-    description: Tenant_A_OP_Zone_VTEP_DIAGNOSTICS
-    shutdown: false
-    vrf: Tenant_A_OP_Zone
-    ip_address: 10.255.1.6/32
+- name: Loopback0
+  description: EVPN_Overlay_Peering
+  shutdown: false
+  ip_address: 192.0.255.6/32
+- name: Loopback1
+  description: VTEP_VXLAN_Tunnel_Source
+  shutdown: false
+  ip_address: 192.0.254.5/32
+- name: Loopback100
+  description: Tenant_A_OP_Zone_VTEP_DIAGNOSTICS
+  shutdown: false
+  vrf: Tenant_A_OP_Zone
+  ip_address: 10.255.1.6/32
 prefix_lists:
-  PL-LOOPBACKS-EVPN-OVERLAY:
-    sequence_numbers:
-      10:
-        action: permit 192.0.255.0/24 eq 32
-      20:
-        action: permit 192.0.254.0/24 eq 32
+- name: PL-LOOPBACKS-EVPN-OVERLAY
+  sequence_numbers:
+  - sequence: 10
+    action: permit 192.0.255.0/24 eq 32
+  - sequence: 20
+    action: permit 192.0.254.0/24 eq 32
 router_bfd:
   multihop:
     interval: 1200
@@ -324,17 +329,17 @@ vxlan_interface:
   Vxlan1:
     description: leaf4_VTEP
     vxlan:
+      udp_port: 4789
       source_interface: Loopback1
       virtual_router_encapsulation_mac_address: mlag-system-id
-      udp_port: 4789
       vlans:
-        110:
-          vni: 10110
-        160:
-          vni: 55160
+      - id: 110
+        vni: 10110
+      - id: 160
+        vni: 55160
       vrfs:
-        Tenant_A_OP_Zone:
-          vni: 10
+      - name: Tenant_A_OP_Zone
+        vni: 10
 virtual_source_nat_vrfs:
-  Tenant_A_OP_Zone:
-    ip_address: 10.255.1.6
+- name: Tenant_A_OP_Zone
+  ip_address: 10.255.1.6

--- a/atd-inventory/intended/structured_configs/spine1.yml
+++ b/atd-inventory/intended/structured_configs/spine1.yml
@@ -1,73 +1,80 @@
 router_bgp:
   as: '65001'
   router_id: 192.0.255.1
-  bgp_defaults:
-  - no bgp default ipv4-unicast
-  - distance bgp 20 200 200
-  - graceful-restart restart-time 300
-  - graceful-restart
-  - maximum-paths 4 ecmp 4
+  distance:
+    external_routes: 20
+    internal_routes: 200
+    local_routes: 200
+  bgp:
+    default:
+      ipv4_unicast: false
+  maximum_paths:
+    paths: 4
+    ecmp: 4
+  graceful_restart:
+    enabled: true
+    restart_time: 300
   peer_groups:
-    IPv4-UNDERLAY-PEERS:
-      type: ipv4
-      password: AQQvKeimxJu+uGQ/yYvv9w==
-      maximum_routes: 12000
-      send_community: all
-    EVPN-OVERLAY-PEERS:
-      type: evpn
-      update_source: Loopback0
-      bfd: true
-      ebgp_multihop: '3'
-      password: q+VNViP5i4rVjW1cxFv2wA==
-      send_community: all
-      maximum_routes: 0
-      next_hop_unchanged: true
+  - name: IPv4-UNDERLAY-PEERS
+    type: ipv4
+    password: AQQvKeimxJu+uGQ/yYvv9w==
+    maximum_routes: 12000
+    send_community: all
+  - name: EVPN-OVERLAY-PEERS
+    type: evpn
+    update_source: Loopback0
+    bfd: true
+    password: q+VNViP5i4rVjW1cxFv2wA==
+    send_community: all
+    maximum_routes: 0
+    ebgp_multihop: 3
+    next_hop_unchanged: true
   address_family_ipv4:
     peer_groups:
-      IPv4-UNDERLAY-PEERS:
-        activate: true
-      EVPN-OVERLAY-PEERS:
-        activate: false
+    - name: IPv4-UNDERLAY-PEERS
+      activate: true
+    - name: EVPN-OVERLAY-PEERS
+      activate: false
   redistribute_routes:
-    connected:
-      route_map: RM-CONN-2-BGP
+  - source_protocol: connected
+    route_map: RM-CONN-2-BGP
   neighbors:
-    172.30.255.1:
-      peer_group: IPv4-UNDERLAY-PEERS
-      remote_as: '65101'
-      description: leaf1_Ethernet2
-    172.30.255.5:
-      peer_group: IPv4-UNDERLAY-PEERS
-      remote_as: '65101'
-      description: leaf2_Ethernet2
-    172.30.255.9:
-      peer_group: IPv4-UNDERLAY-PEERS
-      remote_as: '65102'
-      description: leaf3_Ethernet2
-    172.30.255.13:
-      peer_group: IPv4-UNDERLAY-PEERS
-      remote_as: '65102'
-      description: leaf4_Ethernet2
-    192.0.255.3:
-      peer_group: EVPN-OVERLAY-PEERS
-      description: leaf1
-      remote_as: '65101'
-    192.0.255.4:
-      peer_group: EVPN-OVERLAY-PEERS
-      description: leaf2
-      remote_as: '65101'
-    192.0.255.5:
-      peer_group: EVPN-OVERLAY-PEERS
-      description: leaf3
-      remote_as: '65102'
-    192.0.255.6:
-      peer_group: EVPN-OVERLAY-PEERS
-      description: leaf4
-      remote_as: '65102'
+  - ip_address: 172.30.255.1
+    peer_group: IPv4-UNDERLAY-PEERS
+    remote_as: '65101'
+    description: leaf1_Ethernet2
+  - ip_address: 172.30.255.5
+    peer_group: IPv4-UNDERLAY-PEERS
+    remote_as: '65101'
+    description: leaf2_Ethernet2
+  - ip_address: 172.30.255.9
+    peer_group: IPv4-UNDERLAY-PEERS
+    remote_as: '65102'
+    description: leaf3_Ethernet2
+  - ip_address: 172.30.255.13
+    peer_group: IPv4-UNDERLAY-PEERS
+    remote_as: '65102'
+    description: leaf4_Ethernet2
+  - ip_address: 192.0.255.3
+    peer_group: EVPN-OVERLAY-PEERS
+    description: leaf1
+    remote_as: '65101'
+  - ip_address: 192.0.255.4
+    peer_group: EVPN-OVERLAY-PEERS
+    description: leaf2
+    remote_as: '65101'
+  - ip_address: 192.0.255.5
+    peer_group: EVPN-OVERLAY-PEERS
+    description: leaf3
+    remote_as: '65102'
+  - ip_address: 192.0.255.6
+    peer_group: EVPN-OVERLAY-PEERS
+    description: leaf4
+    remote_as: '65102'
   address_family_evpn:
     peer_groups:
-      EVPN-OVERLAY-PEERS:
-        activate: true
+    - name: EVPN-OVERLAY-PEERS
+      activate: true
 static_routes:
 - vrf: default
   destination_address_prefix: 0.0.0.0/0
@@ -79,83 +86,82 @@ vlan_internal_order:
   range:
     beginning: 1006
     ending: 1199
-name_server:
-  source:
-    vrf: default
-  nodes:
-  - 192.168.2.1
-  - 8.8.8.8
+ip_name_servers:
+- ip_address: 192.168.2.1
+  vrf: default
+- ip_address: 8.8.8.8
+  vrf: default
 spanning_tree:
   mode: none
 vrfs:
-  default:
-    ip_routing: false
+- name: default
+  ip_routing: false
 management_interfaces:
-  Management1:
-    description: oob_management
-    shutdown: false
-    vrf: default
-    ip_address: 192.168.0.10/24
-    gateway: 192.168.0.1
-    type: oob
+- name: Management1
+  description: oob_management
+  shutdown: false
+  vrf: default
+  ip_address: 192.168.0.10/24
+  gateway: 192.168.0.1
+  type: oob
 management_api_http:
   enable_vrfs:
-    default: {}
+  - name: default
   enable_https: true
 ethernet_interfaces:
-  Ethernet2:
-    peer: leaf1
-    peer_interface: Ethernet2
-    peer_type: l3leaf
-    description: P2P_LINK_TO_LEAF1_Ethernet2
-    mtu: 1500
-    type: routed
-    shutdown: false
-    ip_address: 172.30.255.0/31
-  Ethernet3:
-    peer: leaf2
-    peer_interface: Ethernet2
-    peer_type: l3leaf
-    description: P2P_LINK_TO_LEAF2_Ethernet2
-    mtu: 1500
-    type: routed
-    shutdown: false
-    ip_address: 172.30.255.4/31
-  Ethernet4:
-    peer: leaf3
-    peer_interface: Ethernet2
-    peer_type: l3leaf
-    description: P2P_LINK_TO_LEAF3_Ethernet2
-    mtu: 1500
-    type: routed
-    shutdown: false
-    ip_address: 172.30.255.8/31
-  Ethernet5:
-    peer: leaf4
-    peer_interface: Ethernet2
-    peer_type: l3leaf
-    description: P2P_LINK_TO_LEAF4_Ethernet2
-    mtu: 1500
-    type: routed
-    shutdown: false
-    ip_address: 172.30.255.12/31
+- name: Ethernet2
+  peer: leaf1
+  peer_interface: Ethernet2
+  peer_type: l3leaf
+  description: P2P_LINK_TO_LEAF1_Ethernet2
+  shutdown: false
+  mtu: 1500
+  type: routed
+  ip_address: 172.30.255.0/31
+- name: Ethernet3
+  peer: leaf2
+  peer_interface: Ethernet2
+  peer_type: l3leaf
+  description: P2P_LINK_TO_LEAF2_Ethernet2
+  shutdown: false
+  mtu: 1500
+  type: routed
+  ip_address: 172.30.255.4/31
+- name: Ethernet4
+  peer: leaf3
+  peer_interface: Ethernet2
+  peer_type: l3leaf
+  description: P2P_LINK_TO_LEAF3_Ethernet2
+  shutdown: false
+  mtu: 1500
+  type: routed
+  ip_address: 172.30.255.8/31
+- name: Ethernet5
+  peer: leaf4
+  peer_interface: Ethernet2
+  peer_type: l3leaf
+  description: P2P_LINK_TO_LEAF4_Ethernet2
+  shutdown: false
+  mtu: 1500
+  type: routed
+  ip_address: 172.30.255.12/31
 loopback_interfaces:
-  Loopback0:
-    description: EVPN_Overlay_Peering
-    shutdown: false
-    ip_address: 192.0.255.1/32
+- name: Loopback0
+  description: EVPN_Overlay_Peering
+  shutdown: false
+  ip_address: 192.0.255.1/32
 prefix_lists:
-  PL-LOOPBACKS-EVPN-OVERLAY:
-    sequence_numbers:
-      10:
-        action: permit 192.0.255.0/24 eq 32
+- name: PL-LOOPBACKS-EVPN-OVERLAY
+  sequence_numbers:
+  - sequence: 10
+    action: permit 192.0.255.0/24 eq 32
 route_maps:
-  RM-CONN-2-BGP:
-    sequence_numbers:
-      10:
-        type: permit
-        match:
-        - ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY
+- name: RM-CONN-2-BGP
+  sequence_numbers:
+  - sequence: 10
+    type: permit
+    match:
+    - ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY
 router_bfd:
   multihop:
     interval: 1200

--- a/atd-inventory/intended/structured_configs/spine2.yml
+++ b/atd-inventory/intended/structured_configs/spine2.yml
@@ -1,73 +1,80 @@
 router_bgp:
   as: '65001'
   router_id: 192.0.255.2
-  bgp_defaults:
-  - no bgp default ipv4-unicast
-  - distance bgp 20 200 200
-  - graceful-restart restart-time 300
-  - graceful-restart
-  - maximum-paths 4 ecmp 4
+  distance:
+    external_routes: 20
+    internal_routes: 200
+    local_routes: 200
+  bgp:
+    default:
+      ipv4_unicast: false
+  maximum_paths:
+    paths: 4
+    ecmp: 4
+  graceful_restart:
+    enabled: true
+    restart_time: 300
   peer_groups:
-    IPv4-UNDERLAY-PEERS:
-      type: ipv4
-      password: AQQvKeimxJu+uGQ/yYvv9w==
-      maximum_routes: 12000
-      send_community: all
-    EVPN-OVERLAY-PEERS:
-      type: evpn
-      update_source: Loopback0
-      bfd: true
-      ebgp_multihop: '3'
-      password: q+VNViP5i4rVjW1cxFv2wA==
-      send_community: all
-      maximum_routes: 0
-      next_hop_unchanged: true
+  - name: IPv4-UNDERLAY-PEERS
+    type: ipv4
+    password: AQQvKeimxJu+uGQ/yYvv9w==
+    maximum_routes: 12000
+    send_community: all
+  - name: EVPN-OVERLAY-PEERS
+    type: evpn
+    update_source: Loopback0
+    bfd: true
+    password: q+VNViP5i4rVjW1cxFv2wA==
+    send_community: all
+    maximum_routes: 0
+    ebgp_multihop: 3
+    next_hop_unchanged: true
   address_family_ipv4:
     peer_groups:
-      IPv4-UNDERLAY-PEERS:
-        activate: true
-      EVPN-OVERLAY-PEERS:
-        activate: false
+    - name: IPv4-UNDERLAY-PEERS
+      activate: true
+    - name: EVPN-OVERLAY-PEERS
+      activate: false
   redistribute_routes:
-    connected:
-      route_map: RM-CONN-2-BGP
+  - source_protocol: connected
+    route_map: RM-CONN-2-BGP
   neighbors:
-    172.30.255.3:
-      peer_group: IPv4-UNDERLAY-PEERS
-      remote_as: '65101'
-      description: leaf1_Ethernet3
-    172.30.255.7:
-      peer_group: IPv4-UNDERLAY-PEERS
-      remote_as: '65101'
-      description: leaf2_Ethernet3
-    172.30.255.11:
-      peer_group: IPv4-UNDERLAY-PEERS
-      remote_as: '65102'
-      description: leaf3_Ethernet3
-    172.30.255.15:
-      peer_group: IPv4-UNDERLAY-PEERS
-      remote_as: '65102'
-      description: leaf4_Ethernet3
-    192.0.255.3:
-      peer_group: EVPN-OVERLAY-PEERS
-      description: leaf1
-      remote_as: '65101'
-    192.0.255.4:
-      peer_group: EVPN-OVERLAY-PEERS
-      description: leaf2
-      remote_as: '65101'
-    192.0.255.5:
-      peer_group: EVPN-OVERLAY-PEERS
-      description: leaf3
-      remote_as: '65102'
-    192.0.255.6:
-      peer_group: EVPN-OVERLAY-PEERS
-      description: leaf4
-      remote_as: '65102'
+  - ip_address: 172.30.255.3
+    peer_group: IPv4-UNDERLAY-PEERS
+    remote_as: '65101'
+    description: leaf1_Ethernet3
+  - ip_address: 172.30.255.7
+    peer_group: IPv4-UNDERLAY-PEERS
+    remote_as: '65101'
+    description: leaf2_Ethernet3
+  - ip_address: 172.30.255.11
+    peer_group: IPv4-UNDERLAY-PEERS
+    remote_as: '65102'
+    description: leaf3_Ethernet3
+  - ip_address: 172.30.255.15
+    peer_group: IPv4-UNDERLAY-PEERS
+    remote_as: '65102'
+    description: leaf4_Ethernet3
+  - ip_address: 192.0.255.3
+    peer_group: EVPN-OVERLAY-PEERS
+    description: leaf1
+    remote_as: '65101'
+  - ip_address: 192.0.255.4
+    peer_group: EVPN-OVERLAY-PEERS
+    description: leaf2
+    remote_as: '65101'
+  - ip_address: 192.0.255.5
+    peer_group: EVPN-OVERLAY-PEERS
+    description: leaf3
+    remote_as: '65102'
+  - ip_address: 192.0.255.6
+    peer_group: EVPN-OVERLAY-PEERS
+    description: leaf4
+    remote_as: '65102'
   address_family_evpn:
     peer_groups:
-      EVPN-OVERLAY-PEERS:
-        activate: true
+    - name: EVPN-OVERLAY-PEERS
+      activate: true
 static_routes:
 - vrf: default
   destination_address_prefix: 0.0.0.0/0
@@ -79,83 +86,82 @@ vlan_internal_order:
   range:
     beginning: 1006
     ending: 1199
-name_server:
-  source:
-    vrf: default
-  nodes:
-  - 192.168.2.1
-  - 8.8.8.8
+ip_name_servers:
+- ip_address: 192.168.2.1
+  vrf: default
+- ip_address: 8.8.8.8
+  vrf: default
 spanning_tree:
   mode: none
 vrfs:
-  default:
-    ip_routing: false
+- name: default
+  ip_routing: false
 management_interfaces:
-  Management1:
-    description: oob_management
-    shutdown: false
-    vrf: default
-    ip_address: 192.168.0.11/24
-    gateway: 192.168.0.1
-    type: oob
+- name: Management1
+  description: oob_management
+  shutdown: false
+  vrf: default
+  ip_address: 192.168.0.11/24
+  gateway: 192.168.0.1
+  type: oob
 management_api_http:
   enable_vrfs:
-    default: {}
+  - name: default
   enable_https: true
 ethernet_interfaces:
-  Ethernet2:
-    peer: leaf1
-    peer_interface: Ethernet3
-    peer_type: l3leaf
-    description: P2P_LINK_TO_LEAF1_Ethernet3
-    mtu: 1500
-    type: routed
-    shutdown: false
-    ip_address: 172.30.255.2/31
-  Ethernet3:
-    peer: leaf2
-    peer_interface: Ethernet3
-    peer_type: l3leaf
-    description: P2P_LINK_TO_LEAF2_Ethernet3
-    mtu: 1500
-    type: routed
-    shutdown: false
-    ip_address: 172.30.255.6/31
-  Ethernet4:
-    peer: leaf3
-    peer_interface: Ethernet3
-    peer_type: l3leaf
-    description: P2P_LINK_TO_LEAF3_Ethernet3
-    mtu: 1500
-    type: routed
-    shutdown: false
-    ip_address: 172.30.255.10/31
-  Ethernet5:
-    peer: leaf4
-    peer_interface: Ethernet3
-    peer_type: l3leaf
-    description: P2P_LINK_TO_LEAF4_Ethernet3
-    mtu: 1500
-    type: routed
-    shutdown: false
-    ip_address: 172.30.255.14/31
+- name: Ethernet2
+  peer: leaf1
+  peer_interface: Ethernet3
+  peer_type: l3leaf
+  description: P2P_LINK_TO_LEAF1_Ethernet3
+  shutdown: false
+  mtu: 1500
+  type: routed
+  ip_address: 172.30.255.2/31
+- name: Ethernet3
+  peer: leaf2
+  peer_interface: Ethernet3
+  peer_type: l3leaf
+  description: P2P_LINK_TO_LEAF2_Ethernet3
+  shutdown: false
+  mtu: 1500
+  type: routed
+  ip_address: 172.30.255.6/31
+- name: Ethernet4
+  peer: leaf3
+  peer_interface: Ethernet3
+  peer_type: l3leaf
+  description: P2P_LINK_TO_LEAF3_Ethernet3
+  shutdown: false
+  mtu: 1500
+  type: routed
+  ip_address: 172.30.255.10/31
+- name: Ethernet5
+  peer: leaf4
+  peer_interface: Ethernet3
+  peer_type: l3leaf
+  description: P2P_LINK_TO_LEAF4_Ethernet3
+  shutdown: false
+  mtu: 1500
+  type: routed
+  ip_address: 172.30.255.14/31
 loopback_interfaces:
-  Loopback0:
-    description: EVPN_Overlay_Peering
-    shutdown: false
-    ip_address: 192.0.255.2/32
+- name: Loopback0
+  description: EVPN_Overlay_Peering
+  shutdown: false
+  ip_address: 192.0.255.2/32
 prefix_lists:
-  PL-LOOPBACKS-EVPN-OVERLAY:
-    sequence_numbers:
-      10:
-        action: permit 192.0.255.0/24 eq 32
+- name: PL-LOOPBACKS-EVPN-OVERLAY
+  sequence_numbers:
+  - sequence: 10
+    action: permit 192.0.255.0/24 eq 32
 route_maps:
-  RM-CONN-2-BGP:
-    sequence_numbers:
-      10:
-        type: permit
-        match:
-        - ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY
+- name: RM-CONN-2-BGP
+  sequence_numbers:
+  - sequence: 10
+    type: permit
+    match:
+    - ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY
 router_bfd:
   multihop:
     interval: 1200

--- a/atd-inventory/inventory.yml
+++ b/atd-inventory/inventory.yml
@@ -54,3 +54,5 @@ all:
     ansible_httpapi_use_ssl: true
     ansible_httpapi_validate_certs: false
     ansible_python_interpreter: $(which python3)
+    avd_data_conversion_mode: error
+    avd_data_validation_mode: error

--- a/atd-inventory/inventory.yml
+++ b/atd-inventory/inventory.yml
@@ -34,12 +34,12 @@ all:
                       ansible_host: 192.168.0.14
                     leaf4:
                       ansible_host: 192.168.0.15
-            ATD_TENANTS_NETWORKS:
-              children:
-                ATD_LEAFS:
-            ATD_SERVERS:
-              children:
-                ATD_LEAFS:
+        ATD_TENANTS_NETWORKS:
+          children:
+            ATD_LEAFS:
+        ATD_SERVERS:
+          children:
+            ATD_LEAFS:
 
   vars:
     ansible_user: arista


### PR DESCRIPTION
Update to ATD-AVD to conform to AVD 4.x data models
Tested with AVD 4.1, including example variable (commented out)

Requires arista-netdevops-community/avd-install#18 to be merged