### PR TITLE
Fix: Update pip installation to address PEP 668

### DIFF
--- a/DEMO.md
+++ b/DEMO.md
@@ -35,6 +35,8 @@ The code block below performs the following actions:
     cd /home/coder/project/labfiles
     ansible-galaxy collection install arista.avd:==4.8.0
     export ARISTA_AVD_DIR=$(ansible-galaxy collection list arista.avd --format yaml | head -1 | cut -d: -f1)
+    pip3 config set global.break-system-packages true
+    pip3 config set global.disable-pip-version-check true
     pip3 install -r ${ARISTA_AVD_DIR}/arista/avd/requirements.txt
     pip3 install 'anta==0.14.0'
     git clone https://github.com/arista-netdevops-community/atd-avd.git

--- a/README.md
+++ b/README.md
@@ -60,6 +60,8 @@ The diagram below shows that the ATD lab topology has two data centers. We will 
     export LABPASSPHRASE=`cat /home/coder/.config/code-server/config.yaml| grep "password:" | awk '{print $2}'`
     ansible-galaxy collection install arista.avd:==4.8.0
     export ARISTA_AVD_DIR=$(ansible-galaxy collection list arista.avd --format yaml | head -1 | cut -d: -f1)
+    pip3 config set global.break-system-packages true
+    pip3 config set global.disable-pip-version-check true
     pip3 install -r ${ARISTA_AVD_DIR}/arista/avd/requirements.txt
     git clone https://github.com/arista-netdevops-community/atd-avd.git
     cd atd-avd


### PR DESCRIPTION
Update pip install to address PEP 668 that prevented pip installation:

```
➜  labfiles pip3 install -r ${ARISTA_AVD_DIR}/arista/avd/requirements.txt
error: externally-managed-environment <--

× This environment is externally managed
╰─> To install Python packages system-wide, try apt install
    python3-xyz, where xyz is the package you are trying to
    install.
    
    If you wish to install a non-Debian-packaged Python package,
    create a virtual environment using python3 -m venv path/to/venv.
    Then use path/to/venv/bin/python and path/to/venv/bin/pip. Make
    sure you have python3-full installed.
    
    If you wish to install a non-Debian packaged Python application,
    it may be easiest to use pipx install xyz, which will manage a
    virtual environment for you. Make sure you have pipx installed.
    
    See /usr/share/doc/python3.11/README.venv for more information.

note: If you believe this is a mistake, please contact your Python installation or OS distribution provider. You can override this, at the risk of breaking your Python installation or OS, by passing --break-system-packages.
hint: See PEP 668 for the detailed specification.
➜  labfiles
```