### PR TITLE
Doc: Add pip config warning to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ The diagram below shows that the ATD lab topology has two data centers. We will 
     ```
 
 2. Set credentials and install any required tools
+> :warning: **Warning:** Specific for the ATD environment. the `pip config` lines disable PIP safety checks and should not be used outside of ATD without understanding them.
 
     ```shell
     cd /home/coder/project/labfiles


### PR DESCRIPTION
Since those lines are disabling safety checks that can potentially damage system libs, adding a warning to not use it without understanding it first.