### PR TITLE
Fixing the switchport in the commented section to match s1-leaf3 and 4

### DIFF
--- a/atd-inventory/group_vars/ATD_SERVERS.yml
+++ b/atd-inventory/group_vars/ATD_SERVERS.yml
@@ -33,7 +33,7 @@ servers:
 
 # network_ports:
 #   - switches:
-#       - s1-leaf[34] # Simple regex to match on leaf3 and leaf4 on spine1
+#       - s1-leaf[34] # Simple regex to match on leaf3 and leaf4
 #     switch_ports: # Ex Ethernet1-48 or Ethernet2-3/1-48
 #       - Ethernet4
 #     description: Connection to host2

--- a/atd-inventory/group_vars/ATD_SERVERS.yml
+++ b/atd-inventory/group_vars/ATD_SERVERS.yml
@@ -33,7 +33,7 @@ servers:
 
 # network_ports:
 #   - switches:
-#       - leaf[34] # Simple regex to match on leaf3 and leaf4
+#       - s1-leaf[34] # Simple regex to match on leaf3 and leaf4 on spine1
 #     switch_ports: # Ex Ethernet1-48 or Ethernet2-3/1-48
 #       - Ethernet4
 #     description: Connection to host2


### PR DESCRIPTION
In the comments for atd-inventory/group_vars/ATD_SERVERS.yml when following the tutorial doc uncommenting does not work as the name is incorrect. This update will fix that issue by adding "s1-"